### PR TITLE
Enhancements and upgrades to `Makefile` for Improved dependency management

### DIFF
--- a/build/Makefile
+++ b/build/Makefile
@@ -29,10 +29,9 @@ FC = gfortran
 # find HDF5
 # Check if pkg-config is available for HDF5
 # Check if all required environment variables are set
-ifneq ($(HDF5_PREFIX)$(HDF5_CFLAGS)$(HDF5_LIBS),)
+ifneq ($(HDF5_LIB_DIR)$(HDF5_INCLUDE_DIR),)
   # If all variables are set, proceed
-  HDF5_INCLUDE_DIR = $(HDF5_PREFIX)/include
-  HDF5_LIB_DIR = $(HDF5_PREFIX)/lib
+  :
 else
   # check if the `pkg-config' is available
   HAS_PKG_CONFIG := $(shell pkg-config --exists hdf5 && echo yes)
@@ -41,36 +40,46 @@ else
     HDF5_INCLUDE_DIR := $(shell pkg-config --variable=includedir hdf5)
     HDF5_LIB_DIR := $(shell pkg-config --variable=libdir hdf5)
   else
-    $(error "pkg-config for HDF5 is not available. Set HDF5_INCLUDE_DIR and HDF5_LIB_DIR environment variables manually.")
+    $(error "pkg-config for HDF5 is not available. Set HDF5_INCLUDE_DIR and HDF5_LIB_DIR environment variables manually")
   endif # pkg-config ... hdf5
 endif # HDF5
 
 # netcdf-c
 # Use the nc-config to set the proper flags
 # Check if nc-config is available
-ifneq ($(shell which nc-config 2>/dev/null),)
-  NETCDF_C_CFLAGS := $(shell nc-config --cflags)
-  NETCDF_C_LIBS := $(shell nc-config --libdir)
+ifneq ($(NETCDF_C_PREFIX),)
+    NETCDF_C_INCLUDE := $(NETCDF_C_PREFIX)/include
+    NETCDF_C_LIB := $(NETCDF_C_PREFIX)/lib
 else
-  $(error nc-config not found. Please install netcdf-c library.)
+  ifneq ($(shell which nc-config 2>/dev/null),)
+    NETCDF_C_INCLUDE := $(shell nc-config --includedir)
+    NETCDF_C_LIB := $(shell nc-config --libdir)
+  else
+    $(error nc-config not found. Please install netcdf-c library, or set NETCDF_C_PREFIX manually)
+  endif
 endif
 
 # netcdf-fortran
 # Use the nf-config to set the proper flags
 # Check if nf-config is available
-ifneq ($(shell which nf-config 2>/dev/null),)
-  NETCDF_F_FFLAGS := $(shell nf-config --fflags)
-  NETCDF_F_LIBS := $(shell nf-config --prefix)/lib
+ifneq ($(NETCDF_F_PREFIX),)
+    NETCDF_F_INCLUDE := $(NETCDF_F_PREFIX)/include
+    NETCDF_F_LIB := $(NETCDF_F_PREFIX)/lib
 else
-  $(error nf-config not found. Please install netcdf-fortran library.)
+  ifneq ($(shell which nf-config 2>/dev/null),)
+    NETCDF_F_INCLUDE := $(shell nf-config --includedir)
+    NETCDF_F_LIB := $(shell nf-config --prefix)/lib
+  else
+    $(error nf-config not found. Please install netcdf-fortran library, or set NETCDF_F_PREFIX manually)
+  endif
 endif
 
 # define appropriate flags
-FFLAGS += -I$(HDF5_INCLUDE_DIR) $(NETCDF_C_CFLAGS) $(NETCDF_F_FFLAGS)
-LIBS += -L$(HDF5_LIB_DIR) -lhdf5 -lhdf5_hl -L$(NETCDF_F_LIBS) -lnetcdff -L$(NETCDF_C_LIBS) -lnetcdf
+FFLAGS += -I$(HDF5_INCLUDE_DIR) -I$(NETCDF_C_INCLUDE) -I$(NETCDF_F_INCLUDE)
+LIBS += -L$(HDF5_LIB_DIR) -lhdf5 -lhdf5_hl -L$(NETCDF_F_LIB) -lnetcdff -L$(NETCDF_C_LIB) -lnetcdf
 
-$(info flags are $(FFLAGS))
-$(info libraries are $(LIBS))
+$(info FFLAGS are $(FFLAGS))
+$(info LIBS are $(LIBS))
 
 # Define the driver program and associated subroutines for the fidelity test
 FUSE_DRIVER = \
@@ -303,7 +312,7 @@ endif
 # Compile
 all: compile install clean
 
-# compile FUSE into a static library
+# compile target
 compile: sce_16plus.o
 	$(FC) $(FUSE_ALL) $(DRIVER) \
 	$(LDFLAGS) $(LIBS) $(FFLAGS) -o $(DRIVER_EX)

--- a/build/Makefile
+++ b/build/Makefile
@@ -75,10 +75,10 @@ else
 endif
 
 # define appropriate flags
-FFLAGS += -I$(HDF5_INCLUDE_DIR) -I$(NETCDF_C_INCLUDE) -I$(NETCDF_F_INCLUDE)
+INCLUDES += -I$(HDF5_INCLUDE_DIR) -I$(NETCDF_C_INCLUDE) -I$(NETCDF_F_INCLUDE)
 LIBS += -L$(HDF5_LIB_DIR) -lhdf5 -lhdf5_hl -L$(NETCDF_F_LIB) -lnetcdff -L$(NETCDF_C_LIB) -lnetcdf
 
-$(info FFLAGS are $(FFLAGS))
+$(info INCLUDES are $(INCLUDES))
 $(info LIBS are $(LIBS))
 
 # Define the driver program and associated subroutines for the fidelity test
@@ -275,23 +275,33 @@ FUSE_ALL = \
 #=====================
 # Define flags based on specified compiler
 ifeq ($(FC),ifort)
-  LDFLAGS_NORMA = -O3 -FR -auto -fltconsistency -fpe0 -fpp
-  LDFLAGS_DEBUG = -O0 -p -g -debug -warn all -check all -FR -auto -WB -traceback -fltconsistency -fpe0 -fpp
-  LDFLAGS_FIXED = -O2 -c -fixed
+  FFLAGS_NORMA = -O3 -FR -auto -fltconsistency -fpe0 -fpp
+  FFLAGS_DEBUG = -O0 -p -g -debug -warn all -check all -FR -auto -WB -traceback -fltconsistency -fpe0 -fpp
+  FFLAGS_FIXED = -O2 -c -fixed
 endif
 
 ifeq ($(FC),gfortran)
-  LDFLAGS_NORMA = -O3 -ffree-line-length-none -fmax-errors=0 -cpp -fallow-argument-mismatch
-  LDFLAGS_DEBUG = -p -g -Wall -ffree-line-length-none -fmax-errors=0 -fbacktrace -fcheck=bounds -cpp -fallow-argument-mismatch
-  LDFLAGS_FIXED = -O2 -c -ffixed-form -fallow-argument-mismatch
+  FFLAGS_NORMA = -O3 -ffree-line-length-none -fmax-errors=0 -cpp -fallow-argument-mismatch
+  FFLAGS_DEBUG = -p -g -Wall -ffree-line-length-none -fmax-errors=0 -fbacktrace -fcheck=bounds -cpp -fallow-argument-mismatch
+  FFLAGS_FIXED = -O2 -c -ffixed-form -fallow-argument-mismatch
 endif
 
 # Default flags
-LDFLAGS = $(LDFLAGS_NORMA)
+FFLAGS = $(FFLAGS_NORMA)
 
 # Target-specific flags for 'debug' target
-debug: LDFLAGS = $(LDFLAGS_DEBUG)
+debug: FFLAGS = $(FFLAGS_DEBUG)
 debug: compile
+
+# special provision for gcc>14
+ifeq ($(FC),gfortran)
+  GFORTRAN_VERSION := $(shell gfortran --version 2>/dev/null | head -n 1 | rev | cut -d ' ' -f1 | rev | cut -d '.' -f1)
+  $(info compiler version is $(GFORTRAN_VERSION))
+  # Check if the version is greater than 14
+  ifeq ($(shell [ $(GFORTRAN_VERSION) -ge 14 ] && echo true),true)
+    FFLAGS += -fallow-argument-mismatch
+  endif
+endif
 
 # MPI: FUSE with MPI has been compiled successfully with mpif90 and mpiifort.
 ifeq "$(MODE)" "distributed"
@@ -315,7 +325,7 @@ all: compile install clean
 # compile target
 compile: sce_16plus.o
 	$(FC) $(FUSE_ALL) $(DRIVER) \
-	$(LDFLAGS) $(LIBS) $(FFLAGS) -o $(DRIVER_EX)
+	$(FFLAGS) $(LIBS) $(INCLUDES) -o $(DRIVER_EX)
 
 # Remove object files
 clean:
@@ -330,6 +340,6 @@ install:
 
 # describe how to compile SCE code written in Fortran 77
 sce_16plus.o: $(SCE_DIR)/sce_16plus.f
-	$(FC) $(LDFLAGS_FIXED) -c $(SCE_DIR)/sce_16plus.f
+	$(FC) $(FFLAGS_FIXED) -c $(SCE_DIR)/sce_16plus.f
 
 .PHONY: debug

--- a/build/Makefile
+++ b/build/Makefile
@@ -293,12 +293,13 @@ FFLAGS = $(FFLAGS_NORMA)
 debug: FFLAGS = $(FFLAGS_DEBUG)
 debug: compile
 
-# special provision for gcc>14
+# Special provision for gcc>14
 ifeq ($(FC),gfortran)
-  GFORTRAN_VERSION := $(shell gfortran --version 2>/dev/null | head -n 1 | rev | cut -d ' ' -f1 | rev | cut -d '.' -f1)
+  GFORTRAN_VERSION := $(shell gfortran -dumpversion | cut -d. -f1)
   $(info compiler version is $(GFORTRAN_VERSION))
-  # Check if the version is greater than 14
-  ifeq ($(shell [ $(GFORTRAN_VERSION) -ge 14 ] && echo true),true)
+  GFORTRAN_GT_14 := $(shell expr $(GFORTRAN_VERSION) \>= 14)
+
+  ifeq ($(GFORTRAN_GT_14),1)
     FFLAGS += -fallow-argument-mismatch
   endif
 endif

--- a/build/Makefile
+++ b/build/Makefile
@@ -281,9 +281,9 @@ ifeq ($(FC),ifort)
 endif
 
 ifeq ($(FC),gfortran)
-  FFLAGS_NORMA = -O3 -ffree-line-length-none -fmax-errors=0 -cpp -fallow-argument-mismatch
-  FFLAGS_DEBUG = -p -g -Wall -ffree-line-length-none -fmax-errors=0 -fbacktrace -fcheck=bounds -cpp -fallow-argument-mismatch
-  FFLAGS_FIXED = -O2 -c -ffixed-form -fallow-argument-mismatch
+  FFLAGS_NORMA = -O3 -ffree-line-length-none -fmax-errors=0 -cpp
+  FFLAGS_DEBUG = -p -g -Wall -ffree-line-length-none -fmax-errors=0 -fbacktrace -fcheck=bounds -cpp
+  FFLAGS_FIXED = -O2 -c -ffixed-form
 endif
 
 # Default flags

--- a/build/Makefile
+++ b/build/Makefile
@@ -1,13 +1,13 @@
 #========================================================================
 # Makefile to compile FUSE
 #========================================================================
-#
+
 #========================================================================
 # PART 0: Define directory paths
 #========================================================================
 
 # Define core directory below which everything resides
-F_MASTER = ${HOME}/fuse/
+F_MASTER = $(CURDIR)/../
 
 # Core directory that contains FUSE source code
 F_KORE_DIR = $(F_MASTER)build/FUSE_SRC/
@@ -22,38 +22,61 @@ EXE_PATH = $(F_MASTER)bin/
 # PART 1: Define the libraries, driver programs, and executables
 #========================================================================
 
-# Define the fortran compiler. You have a few options: i) set the FC
-# variable in your environment, ii) set it when you compile this
-# Make file (e.g. make FC=ifort), iii) or if don't define it, the compiler
-# specified below is used
-ifndef FC
-	#FC = ifort
-	FC = gfortran
+# default Fortran compiler is set to `gfortran`
+# other options: ifort
+FC = gfortran
+
+# find HDF5
+# Check if pkg-config is available for HDF5
+# Check if all required environment variables are set
+ifneq ($(HDF5_PREFIX)$(HDF5_CFLAGS)$(HDF5_LIBS),)
+  # If all variables are set, proceed
+  HDF5_INCLUDE_DIR = $(HDF5_PREFIX)/include
+  HDF5_LIB_DIR = $(HDF5_PREFIX)/lib
+else
+  # check if the `pkg-config' is available
+  HAS_PKG_CONFIG := $(shell pkg-config --exists hdf5 && echo yes)
+
+  ifeq ($(HAS_PKG_CONFIG),yes)
+    HDF5_INCLUDE_DIR := $(shell pkg-config --variable=includedir hdf5)
+    HDF5_LIB_DIR := $(shell pkg-config --variable=libdir hdf5)
+  else
+    $(error "pkg-config for HDF5 is not available. Set HDF5_INCLUDE_DIR and HDF5_LIB_DIR environment variables manually.")
+  endif # pkg-config ... hdf5
+endif # HDF5
+
+# netcdf-c
+# Use the nc-config to set the proper flags
+# Check if nc-config is available
+ifneq ($(shell which nc-config 2>/dev/null),)
+  NETCDF_C_CFLAGS := $(shell nc-config --cflags)
+  NETCDF_C_LIBS := $(shell nc-config --libs)
+else
+  $(error nc-config not found. Please install netcdf-c library.)
 endif
 
-# Define the NetCDF and HDF5 libraries. Use the libraries associated with
-# the compiler you selected above. Note that these paths are machine-dependent
-# - consider asking the person in charge of your machine where the libraries are
-# installed. The folders should contain a lib directory - see LIBRARIES below.
-ifeq "$(FC)" "ifort"
-	NCDF_PATH = ${ISCA_NCDF_PATH_ifort}
-	HDF_PATH  = ${ISCA_HDF_PATH_ifort}
+# netcdf-fortran
+# Use the nf-config to set the proper flags
+# Check if nf-config is available
+ifneq ($(shell which nf-config 2>/dev/null),)
+  NETCDF_F_FFLAGS := $(shell nf-config --fflags)
+  NETCDF_F_LIBS := $(shell nf-config --flibs)
+else
+  $(error nf-config not found. Please install netcdf-fortran library.)
 endif
 
-ifeq "$(FC)" "gfortran"
-	NCDF_LIB_PATH = /usr/lib/x86_64-linux-gnu#${NCDF_PATH}
-	HDF_LIB_PATH = /usr/lib/x86_64-linux-gnu/hdf5/serial#${HDF_PATH}
-	INCLUDE_PATH = /usr#${IN_PATH}
-endif
+# define appropriate flags
+FFLAGS += -I$(HDF5_INCLUDE_DIR) $(NETCDF_C_CFLAGS) $(NETCDF_F_FFLAGS)
+LIBS += -L$(HDF5_LIB_DIR) -lhdf5 -lhdf5_hl $(NETCDF_C_LIBS) $(NETCDF_F_LIBS)
 
-LIBRARIES = -L$(NCDF_LIB_PATH)/lib -lnetcdff -lnetcdf -L$(HDF_LIB_PATH)/lib -lhdf5_hl -lhdf5
-INCLUDE = -I$(INCLUDE_PATH)/include -I$(INCLUDE_PATH)/include
+$(info flags are $(FFLAGS))
+$(info libraries are $(LIBS))
 
 # Define the driver program and associated subroutines for the fidelity test
 FUSE_DRIVER = \
-	sobol.f90 \
+  sobol.f90 \
   fuse_rmse.f90 \
-	functn.f90 \
+  functn.f90 \
   fuse_driver.f90
 DRIVER = $(patsubst %, $(DRIVER_DIR)/%, $(FUSE_DRIVER))
 
@@ -75,30 +98,30 @@ TIME_DIR   = $(F_KORE_DIR)FUSE_TIME
 
 # Utility modules
 FUSE_UTILMS= \
-	kinds_dmsl_kit_FUSE.f90 \
-	utilities_dmsl_kit_FUSE.f90 \
-	fuse_fileManager.f90
+  kinds_dmsl_kit_FUSE.f90 \
+  utilities_dmsl_kit_FUSE.f90 \
+  fuse_fileManager.f90
 UTILMS = $(patsubst %, $(HOOKUP_DIR)/%, $(FUSE_UTILMS))
 
 # Numerical Recipes utilities
 FUSE_NRUTIL= \
-	nrtype.f90 \
-	nr.f90 nrutil.f90
+  nrtype.f90 \
+  nr.f90 nrutil.f90
 NRUTIL = $(patsubst %, $(NUMREC_DIR)/%, $(FUSE_NRUTIL))
 
 # Data modules
-FUSE_DATAMS=    \
+FUSE_DATAMS= \
   model_defn.f90 \
-	model_defnames.f90 \
-	multiconst.f90 \
-	multiforce.f90 \
-	multibands.f90 \
-	multiparam.f90 \
-	multistate.f90 \
-	multi_flux.f90 \
-	multiroute.f90 \
-	multistats.f90 \
-	model_numerix.f90
+  model_defnames.f90 \
+  multiconst.f90 \
+  multiforce.f90 \
+  multibands.f90 \
+  multiparam.f90 \
+  multistate.f90 \
+  multi_flux.f90 \
+  multiroute.f90 \
+  multistats.f90 \
+  model_numerix.f90
 DATAMS = $(patsubst %, $(ENGINE_DIR)/%, $(FUSE_DATAMS))
 
 # Time I/O modules
@@ -108,158 +131,172 @@ TIMUTILS = $(patsubst %, $(TIME_DIR)/%, $(FUSE_TIMEMS))
 
 # Information modules
 FUSE_INFOMS= \
-	metaoutput.f90 \
-	metaparams.f90 \
-	meta_stats.f90 \
-	selectmodl.f90 \
-	putpar_str.f90 \
-	getpar_str.f90 \
-	par_insert.f90 \
-	parextract.f90 \
-	varextract.f90 \
-	sumextract.f90 \
-	str_2_xtry.f90 \
-	xtry_2_str.f90
+  metaoutput.f90 \
+  metaparams.f90 \
+  meta_stats.f90 \
+  selectmodl.f90 \
+  putpar_str.f90 \
+  getpar_str.f90 \
+  par_insert.f90 \
+  parextract.f90 \
+  varextract.f90 \
+  sumextract.f90 \
+  str_2_xtry.f90 \
+  xtry_2_str.f90
 INFOMS = $(patsubst %, $(ENGINE_DIR)/%, $(FUSE_INFOMS))
 
 # Numerical Recipes
 FUSE_NR_SUB= \
-	ludcmp.f90 lubksb.f90 svbksb.f90 svdcmp.f90 pythag.f90 \
-	gammln.f90 gammp.f90 gcf.f90 gser.f90
+  ludcmp.f90 \
+  lubksb.f90 \
+  svbksb.f90 \
+  svdcmp.f90 \
+  pythag.f90 \
+  gammln.f90 \
+  gammp.f90 \
+  gcf.f90 \
+  gser.f90
 NR_SUB = $(patsubst %, $(NUMREC_DIR)/%, $(FUSE_NR_SUB))
 
 # Model guts
 FUSE_MODGUT=\
-	mod_derivs.f90 \
-	update_swe.f90 \
-	qrainerror.f90 \
-	qsatexcess.f90 \
-	evap_upper.f90 \
-	evap_lower.f90 \
-	qinterflow.f90 \
-	qpercolate.f90 \
-	q_baseflow.f90 \
-	q_misscell.f90 \
-	logismooth.f90 \
-	mstate_eqn.f90 \
-	fix_states.f90 \
-	meanfluxes.f90 \
-	wgt_fluxes.f90 \
-	updatstate.f90 \
-	q_overland.f90
+  mod_derivs.f90 \
+  update_swe.f90 \
+  qrainerror.f90 \
+  qsatexcess.f90 \
+  evap_upper.f90 \
+  evap_lower.f90 \
+  qinterflow.f90 \
+  qpercolate.f90 \
+  q_baseflow.f90 \
+  q_misscell.f90 \
+  logismooth.f90 \
+  mstate_eqn.f90 \
+  fix_states.f90 \
+  meanfluxes.f90 \
+  wgt_fluxes.f90 \
+  updatstate.f90 \
+  q_overland.f90
 MODGUT = $(patsubst %, $(ENGINE_DIR)/%, $(FUSE_MODGUT))
 
 # Solver
 FUSE_SOLVER= \
-	interfaceb.f90 \
-	limit_xtry.f90 \
-	viol_state.f90 \
-	fuse_deriv.f90 \
-	fmin.f90 fdjac_ode.f90 flux_deriv.f90 disaggflux.f90 \
-	fuse_sieul.f90 \
-	newtoniter.f90 lnsrch.f90
+  interfaceb.f90 \
+  limit_xtry.f90 \
+  viol_state.f90 \
+  fuse_deriv.f90 \
+  fmin.f90 \
+  fdjac_ode.f90 \
+  flux_deriv.f90 \
+  disaggflux.f90 \
+  fuse_sieul.f90 \
+  newtoniter.f90 \
+  lnsrch.f90
 SOLVER = $(patsubst %, $(ENGINE_DIR)/%, $(FUSE_SOLVER))
 
 # Define routines for FUSE preliminaries
 FUSE_PRELIM= \
-	ascii_util.f90 \
-	uniquemodl.f90 \
-	getnumerix.f90 \
-	getparmeta.f90 \
-	assign_stt.f90 \
-	assign_flx.f90 \
-	assign_par.f90 \
-	adjust_stt.f90 \
-	par_derive.f90 \
-	bucketsize.f90 \
-	mean_tipow.f90 \
-	qbsaturatn.f90 \
-	qtimedelay.f90 \
-	init_stats.f90 \
-	init_state.f90
+  ascii_util.f90 \
+  uniquemodl.f90 \
+  getnumerix.f90 \
+  getparmeta.f90 \
+  assign_stt.f90 \
+  assign_flx.f90 \
+  assign_par.f90 \
+  adjust_stt.f90 \
+  par_derive.f90 \
+  bucketsize.f90 \
+  mean_tipow.f90 \
+  qbsaturatn.f90 \
+  qtimedelay.f90 \
+  init_stats.f90 \
+  init_state.f90
 PRELIM = $(patsubst %, $(ENGINE_DIR)/%, $(FUSE_PRELIM))
 
 FUSE_MODRUN= \
-	conv_funcs.f90 \
-	force_info.f90 \
-	clrsky_rad.f90 \
-	getPETgrid.f90 \
-	get_mbands.f90 \
-	get_time_indices.f90\
-	initfluxes.f90 \
-	set_all.f90 \
-	ode_int.f90 \
-	fuse_solve.f90 \
-	comp_stats.f90 \
-	mean_stats.f90
+  conv_funcs.f90 \
+  force_info.f90 \
+  clrsky_rad.f90 \
+  getPETgrid.f90 \
+  get_mbands.f90 \
+  get_time_indices.f90\
+  initfluxes.f90 \
+  set_all.f90 \
+  ode_int.f90 \
+  fuse_solve.f90 \
+  comp_stats.f90 \
+  mean_stats.f90
 MODRUN = $(patsubst %, $(ENGINE_DIR)/%, $(FUSE_MODRUN))
 
 # Define NetCDF routines
 FUSE_NETCDF = \
-    handle_err.f90 \
-    extractor.f90 juldayss.f90 caldatss.f90 \
-    get_gforce.f90 \
-    get_smodel.f90 \
-		get_fparam.f90 \
-    def_params.f90 \
-    def_output.f90 \
-    def_sstats.f90 \
-    put_params.f90 \
-    put_output.f90 \
-    put_sstats.f90
+  handle_err.f90 \
+  extractor.f90 juldayss.f90 caldatss.f90 \
+  get_gforce.f90 \
+  get_smodel.f90 \
+  get_fparam.f90 \
+  def_params.f90 \
+  def_output.f90 \
+  def_sstats.f90 \
+  put_params.f90 \
+  put_output.f90 \
+  put_sstats.f90
 NETCDF = $(patsubst %, $(NETCDF_DIR)/%, $(FUSE_NETCDF))
 
 SCE = \
-	sce_16plus.o
+  sce_16plus.o
 
 # ... and stitch it all together...
-FUSE_ALL = $(UTILMS) $(NRUTIL) $(DATAMS) $(TIMUTILS) $(INFOMS) \
-	$(NR_SUB) $(MODGUT) $(SOLVER) $(PRELIM) $(MODRUN) \
-	$(NETCDF) $(SCE)
+FUSE_ALL = \
+  $(UTILMS) \
+  $(NRUTIL) \
+  $(DATAMS) \
+  $(TIMUTILS) \
+  $(INFOMS) \
+  $(NR_SUB) \
+  $(MODGUT) \
+  $(SOLVER) \
+  $(PRELIM) \
+  $(MODRUN) \
+  $(NETCDF) \
+  $(SCE)
 
-#========================================================================
-# PART 3: Compile the puppy
-#========================================================================
-
-# Define flags - these are compiler-dependent
-ifeq "$(FC)" "ifort"
-
- FLAGS_NORMA = -O3 -FR -auto -fltconsistency -fpe0 -fpp
- FLAGS_DEBUG = -O0 -p -g -debug -warn all -check all -FR -auto -WB -traceback -fltconsistency -fpe0 -fpp
- FLAGS_DEBUG = -O0 -p -g -debug -check all -FR -auto -WB -traceback -fltconsistency -fpe0 -fpp # without -warn all
- FLAGS_FIXED = -O2 -c -fixed
-
+#=====================
+# PART 3: Compile fuse
+#=====================
+# Define flags based on specified compiler
+ifeq ($(FC),ifort)
+  LDFLAGS_NORMA = -O3 -FR -auto -fltconsistency -fpe0 -fpp
+  LDFLAGS_DEBUG = -O0 -p -g -debug -warn all -check all -FR -auto -WB -traceback -fltconsistency -fpe0 -fpp
+  LDFLAGS_FIXED = -O2 -c -fixed
 endif
 
-ifeq "$(FC)" "gfortran"
-
- FLAGS_NORMA = -O3 -ffree-line-length-none -fmax-errors=0 -cpp
- FLAGS_DEBUG = -p -g -Wall -ffree-line-length-none -fmax-errors=0 -fbacktrace -fcheck=bounds -cpp
- FLAGS_DEBUG = -p -Og -ffree-line-length-none -fmax-errors=0 -fcheck=bounds -cpp # without -warn all
- FLAGS_FIXED = -O2 -c -ffixed-form
-
+ifeq ($(FC),gfortran)
+  LDFLAGS_NORMA = -O3 -ffree-line-length-none -fmax-errors=0 -cpp -fallow-argument-mismatch
+  LDFLAGS_DEBUG = -p -g -Wall -ffree-line-length-none -fmax-errors=0 -fbacktrace -fcheck=bounds -cpp -fallow-argument-mismatch
+  LDFLAGS_FIXED = -O2 -c -ffixed-form -fallow-argument-mismatch
 endif
 
-# select a set of flags
-FLAGS = $(FLAGS_NORMA)
-#FLAGS = $(FLAGS_DEBUG)
+# Default flags
+LDFLAGS = $(LDFLAGS_NORMA)
+
+# Target-specific flags for 'debug' target
+debug: LDFLAGS = $(LDFLAGS_DEBUG)
+debug: compile
 
 # MPI: FUSE with MPI has been compiled successfully with mpif90 and mpiifort.
-# Note: override must be specifed to enable FC passed as argument to be overridden
-# https://www.gnu.org/software/make/manual/html_node/Override-Directive.html#Override-Directive
-
 ifeq "$(MODE)" "distributed"
 
-	ifeq "$(FC)" "ifort"
-	 override FC = mpiifort
-	endif
+  ifeq "$(FC)" "ifort"
+    override FC = mpiifort
+  endif
 
-	ifeq "$(FC)" "gfortran"
-		override FC = mpif90
-	endif
+  ifeq "$(FC)" "gfortran"
+    override FC = mpif90
+  endif
 
-	MPI_FLAGS = -D__MPI__
-	DRIVER_EX = fuse_mpi.exe
+  MPI_FLAGS = -D__MPI__
+  DRIVER_EX = fuse_mpi.exe
 
 endif
 
@@ -268,8 +305,8 @@ all: compile install clean
 
 # compile FUSE into a static library
 compile: sce_16plus.o
-	$(FC) $(FLAGS) $(FUSE_ALL) $(DRIVER) \
-	$(LIBRARIES) $(INCLUDE) $(MPI_FLAGS) -o $(DRIVER_EX)
+	$(FC) $(FUSE_ALL) $(DRIVER) \
+	$(LDFLAGS) $(FFLAGS) -o $(DRIVER_EX)
 
 # Remove object files
 clean:
@@ -284,4 +321,6 @@ install:
 
 # describe how to compile SCE code written in Fortran 77
 sce_16plus.o: $(SCE_DIR)/sce_16plus.f
-	$(FC) $(FLAGS_FIXED) $(SCE_DIR)/sce_16plus.f
+	$(FC) $(LDFLAGS_FIXED) -c $(SCE_DIR)/sce_16plus.f
+
+.PHONY: debug

--- a/build/Makefile
+++ b/build/Makefile
@@ -50,7 +50,7 @@ endif # HDF5
 # Check if nc-config is available
 ifneq ($(shell which nc-config 2>/dev/null),)
   NETCDF_C_CFLAGS := $(shell nc-config --cflags)
-  NETCDF_C_LIBS := $(shell nc-config --libs)
+  NETCDF_C_LIBS := $(shell nc-config --libdir)
 else
   $(error nc-config not found. Please install netcdf-c library.)
 endif
@@ -60,14 +60,14 @@ endif
 # Check if nf-config is available
 ifneq ($(shell which nf-config 2>/dev/null),)
   NETCDF_F_FFLAGS := $(shell nf-config --fflags)
-  NETCDF_F_LIBS := $(shell nf-config --flibs)
+  NETCDF_F_LIBS := $(shell nf-config --prefix)/lib
 else
   $(error nf-config not found. Please install netcdf-fortran library.)
 endif
 
 # define appropriate flags
 FFLAGS += -I$(HDF5_INCLUDE_DIR) $(NETCDF_C_CFLAGS) $(NETCDF_F_FFLAGS)
-LIBS += -L$(HDF5_LIB_DIR) -lhdf5 -lhdf5_hl $(NETCDF_C_LIBS) $(NETCDF_F_LIBS)
+LIBS += -L$(HDF5_LIB_DIR) -lhdf5 -lhdf5_hl -L$(NETCDF_F_LIBS) -lnetcdff -L$(NETCDF_C_LIBS) -lnetcdf
 
 $(info flags are $(FFLAGS))
 $(info libraries are $(LIBS))
@@ -306,7 +306,7 @@ all: compile install clean
 # compile FUSE into a static library
 compile: sce_16plus.o
 	$(FC) $(FUSE_ALL) $(DRIVER) \
-	$(LDFLAGS) $(FFLAGS) -o $(DRIVER_EX)
+	$(LDFLAGS) $(LIBS) $(FFLAGS) -o $(DRIVER_EX)
 
 # Remove object files
 clean:


### PR DESCRIPTION
**Description:**  
This PR introduces several enhancements and upgrades to the Makefile to improve compatibility with modern toolchains and streamline dependency management. The key changes include:  

1. **gfortran >14 Compatibility:**  
   Added the `-fallow-argument-mismatch` flag to support gfortran versions greater than 14, as the Fortran code is not fully compatible with these versions. This compromise ensures the code can still be compiled with newer compilers.  

2. **HDF5 Library Detection:**  
   The Makefile now uses `pkg-config` to locate HDF5 library paths and include directories, improving robustness and flexibility in finding the correct HDF5 installation.  

3. **NetCDF Dependency Management:**  
   The Makefile now requires `nc-config` and `nf-config` (provided by netcdf-c and netcdf-fortran, respectively) to locate necessary header/module files and shared libraries. This ensures proper linking and compilation with NetCDF dependencies.  

4. **User Flexibility for Dependency Paths:**  
   Preliminary error-checking mechanisms have been added to ensure users have the flexibility to set the `_PREFIX` value for the three main dependencies: HDF5, NetCDF-C, and NetCDF-Fortran. This provides better control over custom installations and paths.

5. **Adding `debug` Target**
    Users can now compile a `debug` version using `make debug`

These changes aim to improve the build process, enhance compatibility with modern toolchains, and provide a more user-friendly experience for setting up and compiling the project.  

**Testing:**  
- Verified compilation with gfortran versions 8 and 14,  
- Tested `pkg-config` and `nf/nc-config` tools to ensure correct detection of HDF5 and NetCDF dependencies.  
- Confirmed the ability to set custom `*_PREFIX` values for dependencies.  

**Notes:**  
Users are encouraged to update their local installations of HDF5, NetCDF-C, and NetCDF-Fortran to ensure compatibility with these changes.  If necessary libraries are not found, users are able to set the following environment variables prior to compiling the program
- `NETCDF_C_PREFIX`
- `NETCDF_F_PREFIX`
- `HDF5_LIB_DIR` and `HDF5_INCLUDE_DIR`

Let me know if there are any questions or additional feedback!

I think it makes sense if Cyril and Nico give this `PR` a test on contribute to it if necessary.