### PR TITLE
define baseline: print fuse version to output files

### DIFF
--- a/build/FUSE_SRC/dshare/globaldata.f90
+++ b/build/FUSE_SRC/dshare/globaldata.f90
@@ -1,0 +1,36 @@
+MODULE globaldata
+
+ USE nrtype
+ 
+ implicit none
+ include "fuseversion.inc"
+
+ ! time step
+ REAL(SP), save          :: CURRENT_DT            ! current time step (days)
+
+ ! missing values
+ INTEGER(I4B),PARAMETER  :: NA_VALUE=-9999        ! integer designating missing values - TODO: retrieve from NetCDF file
+ REAL(SP),PARAMETER      :: NA_VALUE_SP=-9999_sp  ! integer designating missing values - TODO: retrieve from NetCDF file
+
+ ! NetCDF
+ integer(i4b), save      :: ncid_out=-1           ! NetCDF output file ID
+
+ ! initial store fraction (initialization)
+ real(sp), parameter     :: fracState0=0.25_sp
+
+ ! original code
+ logical(lgt), save      :: isOriginal=.true.
+
+ ! print flag
+ logical(lgt), save      :: isPrint=.true.
+ logical(lgt), save      :: isDebug=.false.
+
+ ! snow parameters
+ integer(i4b), parameter :: NPAR_SNOW=7
+ integer(i4b), parameter :: iMBASE=1, iMFMAX=2, iMFMIN=3, iPXTEMP=4, iOPG=5, iLAPSE=6  ! indices in vectors
+ integer(i4b), parameter :: iPERR=7   ! not a snow parameter, but used here
+
+ ! number of fuse evaluations
+ integer(i4b), save      :: nFUSE_eval    
+
+end MODULE globaldata

--- a/build/FUSE_SRC/netcdf/def_output.f90
+++ b/build/FUSE_SRC/netcdf/def_output.f90
@@ -11,7 +11,7 @@ SUBROUTINE DEF_OUTPUT(nSpat1,nSpat2,NPSET,NTIM)
   ! ---------------------------------------------------------------------------------------
 
   USE nrtype                                            ! variable types, etc.
-  USE model_defn                                        ! model definition (includes filename)
+  USE model_defn, only: FNAME_NETCDF_RUNS               ! model definition (includes filename)
   USE metaoutput                                        ! metadata for all model variables
   USE fuse_fileManager,only: Q_ONLY                     ! only write streamflow to output file?
   USE multiforce, only: GRID_FLAG                          ! .true. if distributed
@@ -20,6 +20,8 @@ SUBROUTINE DEF_OUTPUT(nSpat1,nSpat2,NPSET,NTIM)
   USE multiforce, only: latUnits,lonUnits               ! units string
   USE multiforce, only: timeUnits                       ! units string
   USE multistate, only: ncid_out                        ! NetCDF output file ID
+  USE globaldata, only: FUSE_VERSION, FUSE_BUILDTIME, FUSE_GITBRANCH, FUSE_GITHASH
+
 
   IMPLICIT NONE
 
@@ -161,6 +163,13 @@ SUBROUTINE DEF_OUTPUT(nSpat1,nSpat2,NPSET,NTIM)
     ierr = nf_put_att_text(ncid_out,ivar_id,'units',1,'-'); call handle_err(ierr)
   ENDIF
 
+    ! add global attributes
+    ierr = NF_PUT_ATT_TEXT(ncid_out, NF_GLOBAL, "software",        len("FUSE"),              "FUSE");               call HANDLE_ERR(ierr)
+    ierr = NF_PUT_ATT_TEXT(ncid_out, NF_GLOBAL, "fuse_version",    len_trim(FUSE_VERSION),   trim(FUSE_VERSION));   call HANDLE_ERR(ierr)
+    ierr = NF_PUT_ATT_TEXT(ncid_out, NF_GLOBAL, "fuse_build_time", len_trim(FUSE_BUILDTIME), trim(FUSE_BUILDTIME)); call HANDLE_ERR(ierr)
+    ierr = NF_PUT_ATT_TEXT(ncid_out, NF_GLOBAL, "fuse_git_branch", len_trim(FUSE_GITBRANCH), trim(FUSE_GITBRANCH)); call HANDLE_ERR(ierr)
+    ierr = NF_PUT_ATT_TEXT(ncid_out, NF_GLOBAL, "fuse_git_hash",   len_trim(FUSE_GITHASH),   trim(FUSE_GITHASH));   call HANDLE_ERR(ierr)
+
   ! end definitions
   IERR = NF_ENDDEF(ncid_out); call handle_err(ierr)
 
@@ -187,6 +196,7 @@ SUBROUTINE DEF_OUTPUT(nSpat1,nSpat2,NPSET,NTIM)
   ELSE
     PRINT *, 'NetCDF file for model runs defined with dimensions', nSpat1 , nSpat2, NTIM
   ENDIF
+
 
   IERR = NF_ENDDEF(ncid_out)
   IERR = NF_CLOSE(ncid_out)

--- a/build/FUSE_SRC/netcdf/def_params.f90
+++ b/build/FUSE_SRC/netcdf/def_params.f90
@@ -10,10 +10,11 @@ SUBROUTINE DEF_PARAMS(NPAR)
 ! Define NetCDF output files -- parameter variables
 ! ---------------------------------------------------------------------------------------
 USE nrtype                                            ! variable types, etc.
-USE model_defn                                        ! model definition (includes filename)
+USE model_defn, only: FNAME_NETCDF_PARA               ! model definition (includes filename)
 USE metaparams                                        ! metadata for all model parameters
 USE multistats, ONLY: MSTATS                          ! model statistics structure
 USE multistate, only: ncid_out                        ! NetCDF output file ID
+USE globaldata, only: FUSE_VERSION, FUSE_BUILDTIME, FUSE_GITBRANCH, FUSE_GITHASH
 IMPLICIT NONE
 ! input
 INTEGER(I4B), INTENT(IN)               :: NPAR        ! number of parameter sets
@@ -61,6 +62,16 @@ IERR = NF_CREATE(TRIM(FNAME_NETCDF_PARA),NF_CLOBBER,ncid_out); CALL HANDLE_ERR(I
   ! define error messages
  !IERR = NF_DEF_VAR(ncid_out,'error_message',NF_CHAR,3,EVAR,IVAR_ID); CALL HANDLE_ERR(IERR)
 ! end definitions and close file
+
+    ! add global attributes
+    ierr = NF_PUT_ATT_TEXT(ncid_out, NF_GLOBAL, "software",        len("FUSE"),              "FUSE");               call HANDLE_ERR(ierr)
+    ierr = NF_PUT_ATT_TEXT(ncid_out, NF_GLOBAL, "fuse_version",    len_trim(FUSE_VERSION),   trim(FUSE_VERSION));   call HANDLE_ERR(ierr)
+    ierr = NF_PUT_ATT_TEXT(ncid_out, NF_GLOBAL, "fuse_build_time", len_trim(FUSE_BUILDTIME), trim(FUSE_BUILDTIME)); call HANDLE_ERR(ierr)
+    ierr = NF_PUT_ATT_TEXT(ncid_out, NF_GLOBAL, "fuse_git_branch", len_trim(FUSE_GITBRANCH), trim(FUSE_GITBRANCH)); call HANDLE_ERR(ierr)
+    ierr = NF_PUT_ATT_TEXT(ncid_out, NF_GLOBAL, "fuse_git_hash",   len_trim(FUSE_GITHASH),   trim(FUSE_GITHASH));   call HANDLE_ERR(ierr)
+
+
+
 IERR = NF_ENDDEF(ncid_out)
 IERR = NF_CLOSE(ncid_out)
 ! ---------------------------------------------------------------------------------------

--- a/build/Makefile
+++ b/build/Makefile
@@ -5,7 +5,7 @@
 .DEFAULT_GOAL := all
 
 #========================================================================
-# PART 0: Define directory paths
+# Define directory paths
 #========================================================================
 
 # Define core directory below which everything resides
@@ -21,7 +21,35 @@ MOD_PATH = $(FUSE_ROOT)/build/
 EXE_PATH = $(FUSE_ROOT)/bin/
 
 #========================================================================
-# PART 1: Define the libraries, driver programs, and executables
+# Define an include file (fuseversion.inc) with version info
+#========================================================================
+
+GENINC      := $(FUSE_ROOT)/build/generated
+VERSIONFILE := $(GENINC)/fuseversion.inc
+
+VERSION    := $(shell git -C $(FUSE_ROOT) describe --tags --abbrev=0 2>/dev/null || echo "no-tag")
+BUILDTIME  := $(shell date -u +"%Y-%m-%dT%H:%M:%SZ")
+GITBRANCH  := $(shell git -C $(FUSE_ROOT) rev-parse --abbrev-ref HEAD 2>/dev/null || echo "detached")
+GITHASH    := $(shell git -C $(FUSE_ROOT) rev-parse HEAD 2>/dev/null || echo "unknown")
+
+$(GENINC):
+	@mkdir -p $@
+
+$(VERSIONFILE): | $(GENINC)
+	@{ \
+	  echo "! Auto-generated: do not edit"; \
+	  echo "integer, parameter :: FUSE_VERSION_LEN = 64"; \
+	  echo "integer, parameter :: FUSE_BUILDTIME_LEN = 32"; \
+	  echo "integer, parameter :: FUSE_GITBRANCH_LEN = 64"; \
+	  echo "integer, parameter :: FUSE_GITHASH_LEN = 64"; \
+	  printf "character(len=FUSE_VERSION_LEN),   parameter :: FUSE_VERSION    = '%s'\n" "$(VERSION)"; \
+	  printf "character(len=FUSE_BUILDTIME_LEN), parameter :: FUSE_BUILDTIME  = '%s'\n" "$(BUILDTIME)"; \
+	  printf "character(len=FUSE_GITBRANCH_LEN), parameter :: FUSE_GITBRANCH  = '%s'\n" "$(GITBRANCH)"; \
+	  printf "character(len=FUSE_GITHASH_LEN),   parameter :: FUSE_GITHASH    = '%s'\n" "$(GITHASH)"; \
+	} > $@
+
+#========================================================================
+# Define the libraries, driver programs, and executables
 #========================================================================
 
 # default Fortran compiler is set to `gfortran`
@@ -88,7 +116,7 @@ $(info INCLUDES are $(INCLUDES))
 $(info LIBS are $(LIBS))
 
 #========================================================================
-# PART 2: Assemble all of the FUSE sub-routines
+# Assemble all of the FUSE sub-routines
 #========================================================================
 
 # Define directories
@@ -135,7 +163,7 @@ FUSE_DATAMS =
 FUSE_DATAMS += model_defn.f90
 #FUSE_DATAMS += data_types.f90
 FUSE_DATAMS += model_defnames.f90
-#FUSE_DATAMS += globaldata.f90
+FUSE_DATAMS += globaldata.f90
 FUSE_DATAMS += multiconst.f90
 FUSE_DATAMS += multiforce.f90
 FUSE_DATAMS += multibands.f90
@@ -300,9 +328,9 @@ FUSE_ALL += $(RUNTIME)
 FUSE_ALL += $(NETCDF) 
 FUSE_ALL += $(SCE)
 
-#=====================
-# PART 3: Compile fuse
-#=====================
+#=============
+# Compile fuse
+#=============
 
 # Define flags based on specified compiler
 ifeq ($(FC),ifort)
@@ -318,19 +346,23 @@ ifeq ($(FC),gfortran)
 endif
 
 # Default flags
-FFLAGS = $(FFLAGS_NORMA)
+FFLAGS = $(FFLAGS_NORMA) -I$(GENINC)
 
 # Target-specific flags for 'debug' target
-debug: FFLAGS = $(FFLAGS_DEBUG)
+debug: FFLAGS = $(FFLAGS_DEBUG) -I$(GENINC)
 debug: compile
 
 # Special provision for gcc>13
 ifeq ($(FC),gfortran)
 
-	GFORTRAN_VERSION := $(shell gfortran -dumpversion | cut -d. -f1)
-  $(info compiler version is $(GFORTRAN_VERSION))
-  GFORTRAN_GT_13 := $(shell expr $(GFORTRAN_VERSION) \>= 13)
-
+  GFORTRAN_VERSION_STR := $(shell gfortran -dumpfullversion -dumpversion 2>/dev/null)
+  GFORTRAN_MAJOR       := $(firstword $(subst ., ,$(GFORTRAN_VERSION_STR)))
+  $(info compiler version is $(GFORTRAN_MAJOR))
+  
+  GFORTRAN_MAJOR ?= 0  # if GFORTRAN_MAJOR is empty
+  
+  GFORTRAN_GT_13 := $(shell [ "$(GFORTRAN_MAJOR)" -ge 13 ] && echo 1 || echo 0)
+  
   ifeq ($(GFORTRAN_GT_13),1)
     FFLAGS += -fallow-argument-mismatch
   endif
@@ -360,7 +392,7 @@ sce_16plus.o: $(SCE_DIR)/sce_16plus.f
 all: compile install clean
 
 # compile target
-compile: sce_16plus.o
+compile: sce_16plus.o $(VERSIONFILE)
 	$(FC) $(FUSE_ALL) $(DRIVER) \
 	$(FFLAGS) $(LIBS) $(INCLUDES) -o $(DRIVER_EX)
 
@@ -376,3 +408,4 @@ install:
 	mv $(DRIVER_EX) $(EXE_PATH)
 
 .PHONY: all compile install clean debug
+.PHONY: $(VERSIONFILE)

--- a/build/generated/fuseversion.inc
+++ b/build/generated/fuseversion.inc
@@ -1,0 +1,9 @@
+! Auto-generated: do not edit
+integer, parameter :: FUSE_VERSION_LEN = 64
+integer, parameter :: FUSE_BUILDTIME_LEN = 32
+integer, parameter :: FUSE_GITBRANCH_LEN = 64
+integer, parameter :: FUSE_GITHASH_LEN = 64
+character(len=FUSE_VERSION_LEN),   parameter :: FUSE_VERSION    = 'v2.0.0'
+character(len=FUSE_BUILDTIME_LEN), parameter :: FUSE_BUILDTIME  = '2026-01-03T03:28:59Z'
+character(len=FUSE_GITBRANCH_LEN), parameter :: FUSE_GITBRANCH  = 'refactor/baseline'
+character(len=FUSE_GITHASH_LEN),   parameter :: FUSE_GITHASH    = 'e90e6ea52e9956032bfe114e712398d58db3e9df'


### PR DESCRIPTION
Baseline used for comparison for subsequent development. This baseline is done after re-defining the build layout (directories/files) and after removing all temporary files from the github repo.

The fuse version is included in output files (including branch name and git hash) to simplify comparisons across branches and reproducibility of model results.