### PR TITLE
Support sub-daily forcing time steps and units

### DIFF
--- a/build/FUSE_SRC/driver/fuse_evaluate.f90
+++ b/build/FUSE_SRC/driver/fuse_evaluate.f90
@@ -64,7 +64,7 @@ MODULE fuse_evaluate_module
     if (ierr /= 0) stop "problem allocating w_flux_3d in fuse_evaluate"
 
     ! populate parameter structures and initialize states
-    call initialize_run(XPAR, work, ierr, message)
+    call initialize_run(info, XPAR, work, ierr, message)
     if (ierr /= 0) stop trim(message)
     
     ! initialize timing
@@ -106,14 +106,14 @@ MODULE fuse_evaluate_module
   ! ----- private subroutine initialize_run: populate param sets and initialize states  -------------------------------
   ! -------------------------------------------------------------------------------------------------------------------
 
-  subroutine initialize_run(xpar, work, err, message)
+  subroutine initialize_run(info, xpar, work, err, message)
   
   use fuse_globaldata,  only: isPrint, fracstate0
   use model_defn,  only: SMODL
   use model_defnames
   
   use multiparam,  only: NUMPAR
-  use multiforce,  only: nspat1, nspat2, DELTIM
+  use multiforce,  only: nspat1, nspat2
   use multistate,  only: FSTATE, gState_3d
   use multistats,  only: PCOUNT
   use multibands
@@ -123,8 +123,11 @@ MODULE fuse_evaluate_module
   use str_2_xtry_module
   use xtry_2_str_module
   use put_params_module, only: put_params
+
+  use info_types, only: fuse_info
   implicit none
 
+  type(fuse_info)        , intent(in)      :: info
   real(wp), dimension(:) , intent(in)      :: xpar
   type(fuse_work)        , intent(inout)   :: work
 
@@ -147,7 +150,7 @@ MODULE fuse_evaluate_module
   end if
 
   ! compute derived model parameters (bucket sizes, etc.)
-  call par_derive(err, message)
+  call par_derive(info, err, message)
   if (err /= 0) then
     write(*,*) trim(message)
     stop

--- a/build/FUSE_SRC/driver/setup_domain.f90
+++ b/build/FUSE_SRC/driver/setup_domain.f90
@@ -25,7 +25,7 @@ contains
   USE time_windows_module,   only: get_time_windows             ! get info on the rolling time windows
   USE time_windows_module,   only: export_time_to_multiforce    ! populate legacy multiforce modules
 
-  USE get_gforce_module,     only: get_forcing_varids           ! get name/varid table for forcing variables
+  USE get_gforce_module,     only: get_forcing_metadata         ! get forcing metadata
   USE get_gforce_module,     only: read_latlon_2d               ! read lat/lon
   USE read_elevbands_module, only: read_elevbands               ! read elevation bands
 
@@ -98,7 +98,7 @@ contains
   call read_elevbands(info, domain, ierr, cmessage)
   if (ierr/=0)then; message=trim(message)//trim(cmessage); ierr=20; return; endif
 
-  call get_forcing_varids(info%files%ncid_forc, info, ierr, cmessage)
+  call get_forcing_metadata(info%files%ncid_forc, info, ierr, cmessage)
   if (ierr/=0)then; message=trim(message)//trim(cmessage); ierr=20; return; endif
 
   ! ----- Routines that use the old structures --------------------------------------------

--- a/build/FUSE_SRC/driver/setup_model_definition.f90
+++ b/build/FUSE_SRC/driver/setup_model_definition.f90
@@ -30,13 +30,10 @@ contains
 
   ! data stored in legacy modules
   USE model_defn, only: NSTATE             ! number of state variables
-  USE model_defn, only: TDH_MAX            ! maximum routing delay horizon (days)
   USE multiparam, only: NUMPAR             ! number of paramters for the current model
   USE multiparam, only: LPARAM             ! list of model parameters
   USE multiparam, only: MAXN               ! maximum number of function evaluations in SCE -- used for NUMPSET
-  USE multiparam, only: DPARAM             ! derived model parameters
   USE multiforce, only: NUMPSET            ! number of model parameter sets
-  USE multiroute, only: FUTURE
 
   implicit none
 
@@ -54,8 +51,6 @@ contains
   ! ----- internal -----------------------------------------------------------------------
   INTEGER(I4B)                                      :: IPAR            ! parameter index
   INTEGER(I4B)                                      :: NMOD            ! number of models
-  INTEGER(I4B)                                      :: NTDH            ! number of routing time-delay bins
-  INTEGER(I4B)                                      :: ISTAT           ! allocation status
   TYPE(PARATT)                                      :: PARAM_META      ! parameter metadata (model parameters)
   CHARACTER(LEN=1024)                               :: CMESSAGE        ! error message
   ! ----- output dimensions --------------------------------------------------------------
@@ -87,32 +82,8 @@ contains
   info%config%nParam    = NUMPAR   ! NSTATE is in module multiparam
   info%config%listParam = LPARAM(1:NUMPAR)   ! (performs allocation) LPARAM is in module multiparam
 
-
-  ! Compute the number of routing bins from the maximum routing horizon and the forcing timestep, both expressed in days.
-  NTDH = CEILING(TDH_MAX / info%time%deltim_days, KIND=I4B)
-
-  ! Allocate the runoff fractions assigned to future routing bins.
-  ALLOCATE(DPARAM%FRAC_FUTURE(NTDH), STAT=ISTAT)
-  IF (ISTAT /= 0) THEN
-    ERR = 20
-    MESSAGE = TRIM(MESSAGE)//"cannot allocate DPARAM%FRAC_FUTURE"
-    RETURN
-  ENDIF
-
-  ! Allocate the routing queue using the same number of bins.
-  ALLOCATE(FUTURE(NTDH), STAT=ISTAT)
-  IF (ISTAT /= 0) THEN
-    DEALLOCATE(DPARAM%FRAC_FUTURE)
-    ERR = 20
-    MESSAGE = TRIM(MESSAGE)//"cannot allocate FUTURE"
-    RETURN
-  ENDIF
-
-  ! Initialise the routing queue before the first model evaluation.
-  FUTURE = 0._WP
-
   ! Compute derived model parameters (bucket sizes, etc.)
-  CALL PAR_DERIVE(ERR,CMESSAGE)
+  CALL PAR_DERIVE(info,ERR,CMESSAGE)
   if (err/=0)then; message=trim(message)//trim(cmessage); err=20; return; endif
 
   ! ----- initialize parameters, statistics, and output -----------------------------------

--- a/build/FUSE_SRC/driver/setup_model_definition.f90
+++ b/build/FUSE_SRC/driver/setup_model_definition.f90
@@ -1,10 +1,10 @@
 module setup_model_definition_MODULE
 
   USE nrtype
-  USE info_types, only: fuse_info 
+  USE info_types, only: fuse_info
   USE info_types, only: cli_options
   USE data_types, only: domain_data
-  USE multiparam_types, only: PARATT 
+  USE multiparam_types, only: PARATT
 
   implicit none
 
@@ -30,27 +30,32 @@ contains
 
   ! data stored in legacy modules
   USE model_defn, only: NSTATE             ! number of state variables
+  USE model_defn, only: TDH_MAX            ! maximum routing delay horizon (days)
   USE multiparam, only: NUMPAR             ! number of paramters for the current model
   USE multiparam, only: LPARAM             ! list of model parameters
   USE multiparam, only: MAXN               ! maximum number of function evaluations in SCE -- used for NUMPSET
+  USE multiparam, only: DPARAM             ! derived model parameters
   USE multiforce, only: NUMPSET            ! number of model parameter sets
-  
+  USE multiroute, only: FUTURE
+
   implicit none
-  
+
   ! input
   type(cli_options)   , intent(in)                  :: opts            ! command line interface options
   type(fuse_info)     , intent(inout)               :: info            ! the fuse info structure that stores "everything"
   type(domain_data)   , intent(in)                  :: domain          ! the fuse domain structure that stores data arrays
-  
+
   ! output
   real(wp)            , intent(out) , allocatable   :: aPar(:)         ! parameter vector
   real(wp)            , intent(out) , allocatable   :: BL(:), BU(:)    ! parameter bounds
   integer(i4b)        , intent(out)                 :: err             ! error code
   character(len=1024) , intent(out)                 :: message         ! error message
-  
+
   ! ----- internal -----------------------------------------------------------------------
   INTEGER(I4B)                                      :: IPAR            ! parameter index
   INTEGER(I4B)                                      :: NMOD            ! number of models
+  INTEGER(I4B)                                      :: NTDH            ! number of routing time-delay bins
+  INTEGER(I4B)                                      :: ISTAT           ! allocation status
   TYPE(PARATT)                                      :: PARAM_META      ! parameter metadata (model parameters)
   CHARACTER(LEN=1024)                               :: CMESSAGE        ! error message
   ! ----- output dimensions --------------------------------------------------------------
@@ -66,21 +71,45 @@ contains
   CALL UNIQUEMODL(NMOD)            ! get nmod unique models: stored in module model_defn; NMOD is intent(out)
   CALL GETPARMETA(ERR,CMESSAGE)    ! read parameter metadata from constraints txt file (parameter bounds etc.)
   if (err/=0)then; message=trim(message)//trim(cmessage); err=20; return; endif
-  
+
   ! Identify a single model: FMODEL_ID is read from the control file and used to build string for zDecisions
   CALL SELECTMODL(FMODEL_ID,ERR=ERR,MESSAGE=CMESSAGE) ! FMODEL_ID is intent(in)
   if (err/=0)then; message=trim(message)//trim(cmessage); err=20; return; endif
-  
+
   ! Define list of states and parameters for the current model
   ! NOTE: these definitions are global, so OK to be stored in a shared module
   CALL ASSIGN_STT()        ! state definitions are stored in module model_defn
   CALL ASSIGN_FLX()        ! flux definitions are stored in module model_defn
   CALL ASSIGN_PAR()        ! parameter definitions are stored in module multiparam
- 
+
   ! save information in global data structures
   info%config%nState    = NSTATE   ! NSTATE is in module model_defn
   info%config%nParam    = NUMPAR   ! NSTATE is in module multiparam
   info%config%listParam = LPARAM(1:NUMPAR)   ! (performs allocation) LPARAM is in module multiparam
+
+
+  ! Compute the number of routing bins from the maximum routing horizon and the forcing timestep, both expressed in days.
+  NTDH = CEILING(TDH_MAX / info%time%deltim_days, KIND=I4B)
+
+  ! Allocate the runoff fractions assigned to future routing bins.
+  ALLOCATE(DPARAM%FRAC_FUTURE(NTDH), STAT=ISTAT)
+  IF (ISTAT /= 0) THEN
+    ERR = 20
+    MESSAGE = TRIM(MESSAGE)//"cannot allocate DPARAM%FRAC_FUTURE"
+    RETURN
+  ENDIF
+
+  ! Allocate the routing queue using the same number of bins.
+  ALLOCATE(FUTURE(NTDH), STAT=ISTAT)
+  IF (ISTAT /= 0) THEN
+    DEALLOCATE(DPARAM%FRAC_FUTURE)
+    ERR = 20
+    MESSAGE = TRIM(MESSAGE)//"cannot allocate FUTURE"
+    RETURN
+  ENDIF
+
+  ! Initialise the routing queue before the first model evaluation.
+  FUTURE = 0._WP
 
   ! Compute derived model parameters (bucket sizes, etc.)
   CALL PAR_DERIVE(ERR,CMESSAGE)
@@ -91,13 +120,13 @@ contains
   ! get number of parameter sets
   ! will be used to define the parameter set dimension of the NetCDF files
   select case(trim(opts%runmode))
-    
+
     ! options that run with a single parameter set
     case('def', 'idx', 'opt'); NUMPSET = 1
 
     ! use NUMPSET =1.2MAXN since final number of parameter sets produced by SCE is unknown
-    case('sce');               NUMPSET = int(1.2_wp * real(MAXN, wp)) 
-      
+    case('sce');               NUMPSET = int(1.2_wp * real(MAXN, wp))
+
     ! check
     case default
      message=trim(message)//'opts%runmode is unknown: '//trim(opts%runmode)
@@ -123,10 +152,10 @@ contains
   CALL DEF_PARAMS(nSet)                         ! define model parameters
   CALL DEF_OUTPUT(domain%coords,nx,ny,nb,nPar)  ! define model output time series (nPar used for parameter derivatives)
   CALL DEF_SSTATS()                             ! define summary statistics (REDEF)
- 
+
   ! get parameter bounds and random numbers
   ALLOCATE(APAR(NUMPAR),BL(NUMPAR),BU(NUMPAR))
- 
+
   DO IPAR=1,NUMPAR
    CALL GETPAR_STR(LPARAM(IPAR)%PARNAME,PARAM_META)
    BL(IPAR)   = PARAM_META%PARLOW  ! lower boundary

--- a/build/FUSE_SRC/netcdf/get_gforce.f90
+++ b/build/FUSE_SRC/netcdf/get_gforce.f90
@@ -21,7 +21,7 @@ contains
   ! --------------------------------------------------------------------------------------
   ! --------------------------------------------------------------------------------------
   ! --------------------------------------------------------------------------------------
-  
+
   subroutine read_latlon_2d(ncid, info, coord, ierr, message)
 
   use netcdf
@@ -128,13 +128,13 @@ contains
 
     else
       ! Rectilinear grid: lat(ny), lon(nx) -> broadcast to 2D
-      
+
       ! lon_1d is global length nx_global
       coord%lon_2d(:,:) = spread(lon_1d(1:nx), dim=2, ncopies=ny)
 
       ! lat_1d is global length ny_global; take this rank's slice then replicate across x
       coord%lat_2d(:,:) = spread(lat_1d(ystart:ystart+ny-1), dim=1, ncopies=nx)
-    
+
     endif
 
     deallocate(lat_1d, lon_1d)
@@ -185,41 +185,42 @@ contains
   ! --------------------------------------------------------------------------------------
   subroutine get_dimIds(ncid, varid, nexpect, varDimIDs, ierr, message)
   ! used to get the vector of dimension ids for a given variable
-  
+
   implicit none
-  
+
   ! input
   integer(i4b),intent(in)   :: ncid     ! NetCDF file ID
   integer(i4b),intent(in)   :: varid    ! NetCDF variable ID
   integer(i4b),intent(in)   :: nexpect  ! number of dimensions expected
-  
+
   ! output
   integer(i4b),intent(out)  :: varDimIDs(nexpect)  ! vector of dimension IDs
   integer(i4b),intent(out)  :: ierr     ! error code
   character(*), intent(out) :: message  ! error message
-  
+
   ! internal variables
   integer(i4b)              :: nVarDims ! number of dimensions for given variable
-  
+
   ! initialize error control
   ierr=0; message='get_dimIds/'
-  
+
   ! get number of dimensions
   ierr = nf90_inquire_variable(ncid, varid, ndims=nVarDims)
   if(ierr/=0)then; message=trim(message)//trim(nf90_strerror(ierr)); return; endif
-  
+
   ! check number of dimensions
   if(nVarDims/=nexpect)then; message=trim(message)//'unexpected number of dimensions for variable'; return; endif
-  
+
   ! get vector of dimension IDs
   ierr = nf90_inquire_variable(ncid, varid, dimids=varDimIDs(:nVarDims))
   if(ierr/=0)then; message=trim(message)//trim(nf90_strerror(ierr)); return; endif
-  
+
   end subroutine get_dimIds
-  
+
   ! --------------------------------------------------------------------------------------
- 
+
   subroutine get_forcing_varids(ncid, info, ierr, message)
+  use multiforce, only: amult_ppt, amult_pet, amult_q
   implicit none
   integer(i4b), intent(in)       :: ncid
   type(fuse_info), intent(inout) :: info
@@ -227,6 +228,7 @@ contains
   character(*), intent(out)      :: message
 
   integer(i4b) :: ivar
+  character(len=128) :: units
 
   ierr = 0
   message = "get_forcing_varids/"
@@ -247,12 +249,47 @@ contains
     call lookup_varid(ncid, trim(info%files%forc%name(ivar)), info%files%forc%varid(ivar), ierr, message)
     if(ierr/=0) return
 
+    if (ivar == iTEMP) cycle
+
+    units = ""
+    ierr = nf90_get_att(ncid, info%files%forc%varid(ivar), "units", units)
+
+    if (ierr /= nf90_noerr) then
+      message = trim(message)// "cannot read units for variable '"// trim(info%files%forc%name(ivar))//"': "// trim(nf90_strerror(ierr))
+      return
+    end if
+
+    select case (ivar)
+
+      case (iPRECIP)
+        call get_input_flux_multiplier(units, amult_ppt, ierr, message)
+
+      case (iPET)
+        call get_input_flux_multiplier(units, amult_pet, ierr, message)
+
+      case (iQOBS)
+        call get_input_flux_multiplier(units, amult_q, ierr, message)
+
+      case default
+        ierr = 20
+        message = trim(message)// &
+          "unexpected forcing variable while reading units"
+        return
+
+    end select
+
+    if (ierr /= 0) then
+      message = trim(message)// &
+        " [variable="//trim(info%files%forc%name(ivar))//"]"
+      return
+    end if
+
   end do  ! ivar
 
   contains
-    
-    subroutine lookup_varid(ncid, vname, vid, ierr, message)
-  
+
+   subroutine lookup_varid(ncid, vname, vid, ierr, message)
+
     integer(i4b), intent(in)    :: ncid
     character(len=*), intent(in) :: vname
     integer(i4b), intent(inout) :: vid
@@ -269,12 +306,130 @@ contains
     if (ierr /= 0) then
       message = trim(message)//trim(nf90_strerror(ierr))//" [var="//trim(vname)//"]"
     end if
-    
+
    end subroutine lookup_varid
-  
+
+   subroutine get_input_flux_multiplier(cunits, amult, ierr, message)
+
+    character(len=*), intent(in)    :: cunits
+    real(wp),         intent(out)   :: amult
+    integer(i4b),     intent(inout) :: ierr
+    character(*),     intent(inout) :: message
+
+    character(len=128) :: units_lc
+    character(len=32)  :: length_unit
+    character(len=32)  :: time_unit
+    real(wp)           :: length_to_mm
+    real(wp)           :: time_per_day
+    integer(i4b)       :: ipos
+    integer(i4b)       :: i
+    integer(i4b)       :: ichar_value
+
+    ierr  = 0
+    amult = -1._wp
+
+    units_lc = adjustl(trim(cunits))
+
+    ! Convert ASCII upper case to lower case
+    do i = 1, len_trim(units_lc)
+      ichar_value = iachar(units_lc(i:i))
+
+      if (ichar_value >= iachar("A") .and. &
+          ichar_value <= iachar("Z")) then
+        units_lc(i:i) = achar(ichar_value + 32)
+      end if
+    end do
+
+    ! Current supported syntax: length/time or length per time
+    ipos = index(units_lc, "/")
+
+    if (ipos > 0) then
+
+      ! Syntax: length/time
+      if (ipos <= 1 .or. ipos >= len_trim(units_lc)) then
+         ierr = 20
+         message = trim(message)// &
+          "unsupported flux units '"//trim(cunits)// &
+          "': expected length/time"
+         return
+      end if
+
+      length_unit = adjustl(trim(units_lc(:ipos-1)))
+      time_unit   = adjustl(trim(units_lc(ipos+1:)))
+
+    else
+
+      ! Syntax: length per time
+      ipos = index(units_lc, " per ")
+
+      if (ipos <= 1 .or. ipos + 4 > len_trim(units_lc)) then
+        ierr = 20
+        message = trim(message)// &
+          "unsupported flux units '"//trim(cunits)// &
+          "': expected length/time or length per time"
+        return
+      end if
+
+      length_unit = adjustl(trim(units_lc(:ipos-1)))
+      time_unit   = adjustl(trim(units_lc(ipos+5:)))
+
+    end if
+
+    ! Convert the numerator to millimetres
+    select case (trim(length_unit))
+
+      case ("mm", "millimeter", "millimeters", &
+            "millimetre", "millimetres")
+        length_to_mm = 1._wp
+
+      case ("cm", "centimeter", "centimeters", &
+            "centimetre", "centimetres")
+        length_to_mm = 10._wp
+
+      case ("dm", "decimeter", "decimeters", &
+            "decimetre", "decimetres")
+        length_to_mm = 100._wp
+
+      case ("m", "meter", "meters", &
+            "metre", "metres")
+        length_to_mm = 1000._wp
+
+      case default
+        ierr = 20
+        message = trim(message)// "unsupported length unit '"//trim(length_unit)// "' in '"//trim(cunits)//"'. Supported length units are: mm, cm, dm, m."
+        return
+
+    end select
+
+    ! Convert the denominator to units per day
+    select case (trim(time_unit))
+
+      case ("s", "sec", "secs", "second", "seconds")
+        time_per_day = 86400._wp
+
+      case ("min", "mins", "minute", "minutes")
+        time_per_day = 1440._wp
+
+      case ("h", "hr", "hrs", "hour", "hours")
+        time_per_day = 24._wp
+
+      case ("d", "day", "days")
+        time_per_day = 1._wp
+
+      case default
+        ierr = 20
+        message = trim(message)// "unsupported time unit '"//trim(time_unit)// "' in '"//trim(cunits)//"'. Supported time units are: s, min, h, d."
+        return
+
+    end select
+
+    amult = length_to_mm * time_per_day
+
+   end subroutine get_input_flux_multiplier
+
   end subroutine get_forcing_varids
 
-  
+
   SUBROUTINE get_gforce_3d(info, itim_start, numtim, ierr, message)
   ! ---------------------------------------------------------------------------------------
   ! Creator:
@@ -292,18 +447,19 @@ contains
   ! ---------------------------------------------------------------------------------------
   USE multiforce,only:gForce_3d                          ! gridded forcing data
   USE multiforce,only:aValid                             ! time series of lumped forcing/response data
-  
+  USE multiforce, only: amult_ppt, amult_pet, amult_q
+
   IMPLICIT NONE
-  
+
   ! input
   type(fuse_info), intent(in)             :: info        ! info data structure that holds spatial indices
   integer(i4b),    intent(in)             :: itim_start  ! index of model time step - start of the period to extract
   integer(i4b),    intent(in)             :: numtim      ! number of model time steps to extract
-  
+
   ! output
   integer(i4b),    intent(out)            :: ierr        ! error code
   character(*),    intent(out)            :: message     ! error message
-  
+
   ! internal
   integer(i4b)                            :: iVar        ! loop through forcing data
   real(wp),dimension(:,:,:),allocatable   :: gTemp       ! temporary 3d grid
@@ -311,16 +467,16 @@ contains
   integer(i4b)                            :: ystart       ! start index iin input file (for MPI)
   integer(i4b)                            :: start_3d(3)  ! start indices in NetCDF file
   integer(i4b)                            :: count_3d(3)  ! count in NetCDF file
-  
+
   ! initialize error control
   ierr=0; message='get_gforce_3d/'
   ! ---------------------------------------------------------------------------------------
-  
-  ! 3-d grid dimensions 
+
+  ! 3-d grid dimensions
   nx     = info%space%nx_local
   ny     = info%space%ny_local
   ystart = info%space%y_start_global  ! start index in input file (for MPI)
-  
+
   ! indices for NetCDF rea
   start_3d = (/ 1, ystart, itim_start/)
   count_3d = (/nx,     ny,     numtim/)
@@ -328,12 +484,12 @@ contains
   ! allocate space for the temporary grid
   allocate(gTemp(nx,ny,numtim), stat=ierr)
   if(ierr/=0)then; message=trim(message)//'problem allocating space for gTemp'; return; endif
-  
+
   ! get forcing grids
   do ivar = 1, NVAR_FORC
-  
+
    if(info%space%grid_flag .and. ivar == iQOBS) cycle ! skips qobs if a grid
-  
+
    ! get the data
    ierr = nf90_get_var(info%files%ncid_forc, info%files%forc%varid(ivar), gTemp, start=start_3d, count=count_3d)
    if(ierr/=0)then; message=trim(message)//trim(nf90_strerror(ierr)); return; endif
@@ -341,22 +497,22 @@ contains
    ! save the data in the structure -- and convert fluxes to mm/day
    select case(ivar)
 
-    case (iPRECIP); gForce_3d(:,:,1:numtim)%ppt  = gTemp(:,:,:)
+    case (iPRECIP); gForce_3d(:,:,1:numtim)%ppt  = gTemp(:,:,:) * amult_ppt
     case (iTEMP)  ; gForce_3d(:,:,1:numtim)%temp = gTemp(:,:,:)
-    case (iPET)   ; gForce_3d(:,:,1:numtim)%pet  = gTemp(:,:,:)
-    case (iQOBS)  ; aValid(   :,:,1:numtim)%obsq = gTemp(:,:,:)  ! TODO: check dimensions (works for nx=1, ny=1)
+    case (iPET)   ; gForce_3d(:,:,1:numtim)%pet  = gTemp(:,:,:) * amult_pet
+    case (iQOBS)  ; aValid(   :,:,1:numtim)%obsq = gTemp(:,:,:) * amult_q
     case default
       message=trim(message)//'unable to identify forcing variable'
       ierr=10; return
 
    end select  ! identify forcing variable
-  
+
   end do  ! (loop thru forcing variables)
- 
+
   ! deallocate space for gTemp
   deallocate(gTemp, stat=ierr)
   if(ierr/=0)then; message=trim(message)//'problem deallocating space for gTemp'; return; endif
-  
+
   end subroutine get_gforce_3d
 
 end module get_gforce_module

--- a/build/FUSE_SRC/netcdf/get_gforce.f90
+++ b/build/FUSE_SRC/netcdf/get_gforce.f90
@@ -14,7 +14,7 @@ private
 
 public :: get_gforce_3d
 public :: read_latlon_2d
-public :: get_forcing_varids
+public :: get_forcing_metadata
 
 contains
 
@@ -219,8 +219,7 @@ contains
 
   ! --------------------------------------------------------------------------------------
 
-  subroutine get_forcing_varids(ncid, info, ierr, message)
-  use multiforce, only: amult_ppt, amult_pet, amult_q
+  subroutine get_forcing_metadata(ncid, info, ierr, message)
   implicit none
   integer(i4b), intent(in)       :: ncid
   type(fuse_info), intent(inout) :: info
@@ -231,7 +230,7 @@ contains
   character(len=128) :: units
 
   ierr = 0
-  message = "get_forcing_varids/"
+  message = "get_forcing_metadata/"
 
   ! get table of name/varid pairs (names set in TOML read)
   info%files%forc%name(iPRECIP) = info%files%precip_name
@@ -261,14 +260,8 @@ contains
 
     select case (ivar)
 
-      case (iPRECIP)
-        call get_input_flux_multiplier(units, amult_ppt, ierr, message)
-
-      case (iPET)
-        call get_input_flux_multiplier(units, amult_pet, ierr, message)
-
-      case (iQOBS)
-        call get_input_flux_multiplier(units, amult_q, ierr, message)
+      case (iPRECIP, iPET, iQOBS)
+        call get_input_flux_multiplier(units, info%files%forc%multiplier(ivar), ierr, message)
 
       case default
         ierr = 20
@@ -320,10 +313,21 @@ contains
     character(len=32)  :: length_unit
     character(len=32)  :: time_unit
     real(wp)           :: length_to_mm
-    real(wp)           :: time_per_day
+    real(wp)           :: units_per_day
     integer(i4b)       :: ipos
     integer(i4b)       :: i
     integer(i4b)       :: ichar_value
+
+    integer(i4b), parameter :: syntax_unknown = 0
+    integer(i4b), parameter :: syntax_slash   = 1
+    integer(i4b), parameter :: syntax_per     = 2
+    integer(i4b), parameter :: syntax_inverse = 3
+
+    integer(i4b) :: syntax_type
+    integer(i4b) :: delimiter_len
+    integer(i4b) :: ispace
+
+    character(len=:), allocatable :: delimiter
 
     ierr  = 0
     amult = -1._wp
@@ -340,63 +344,110 @@ contains
       end if
     end do
 
-    ! Current supported syntax: length/time or length per time
-    ipos = index(units_lc, "/")
+    ! Current supported syntax: length/time, length per time and length time-1
+    syntax_type  = syntax_unknown
+    delimiter_len = 0
+    ipos = 0
 
-    if (ipos > 0) then
+    ! Identify the unit syntax.
+    if (index(units_lc, " per ") > 0) then
+      syntax_type = syntax_per
 
-      ! Syntax: length/time
-      if (ipos <= 1 .or. ipos >= len_trim(units_lc)) then
-         ierr = 20
-         message = trim(message)// &
-          "unsupported flux units '"//trim(cunits)// &
-          "': expected length/time"
-         return
-      end if
+    else if (index(units_lc, "/") > 0) then
+      syntax_type = syntax_slash
 
-      length_unit = adjustl(trim(units_lc(:ipos-1)))
-      time_unit   = adjustl(trim(units_lc(ipos+1:)))
-
-    else
-
-      ! Syntax: length per time
-      ipos = index(units_lc, " per ")
-
-      if (ipos <= 1 .or. ipos + 4 > len_trim(units_lc)) then
-        ierr = 20
-        message = trim(message)// &
-          "unsupported flux units '"//trim(cunits)// &
-          "': expected length/time or length per time"
-        return
-      end if
-
-      length_unit = adjustl(trim(units_lc(:ipos-1)))
-      time_unit   = adjustl(trim(units_lc(ipos+5:)))
-
+    else if (index(units_lc, "-1") > 0) then
+      syntax_type = syntax_inverse
     end if
+
+    select case (syntax_type)
+
+      case (syntax_per)
+
+        delimiter = " per "
+        delimiter_len = len(delimiter)
+        ipos = index(units_lc, delimiter)
+
+        if (ipos <= 1 .or. &
+            ipos + delimiter_len > len_trim(units_lc)) then
+          ierr = 20
+          message = trim(message)// &
+            "unsupported flux units '"//trim(cunits)//"': empty length or time unit"
+          return
+        end if
+
+        length_unit = adjustl(trim(units_lc(:ipos-1)))
+        time_unit = adjustl(trim( &
+          units_lc(ipos+delimiter_len:len_trim(units_lc)) ))
+
+      case (syntax_slash)
+
+        delimiter = "/"
+        delimiter_len = len(delimiter)
+        ipos = index(units_lc, delimiter)
+
+        if (ipos <= 1 .or. &
+            ipos + delimiter_len > len_trim(units_lc)) then
+          ierr = 20
+          message = trim(message)//"unsupported flux units '"//trim(cunits)// "': empty length or time unit"
+          return
+        end if
+
+        length_unit = adjustl(trim(units_lc(:ipos-1)))
+        time_unit = adjustl(trim( &
+          units_lc(ipos+delimiter_len:len_trim(units_lc)) ))
+
+      case (syntax_inverse)
+
+        ! Expected syntax: length time-1
+        ispace = index(trim(units_lc), " ")
+
+        if (ispace <= 1) then
+          ierr = 20
+          message = trim(message)// &
+            "unsupported flux units '"//trim(cunits)//"': expected length time-1"
+          return
+        end if
+
+        length_unit = adjustl(trim(units_lc(:ispace-1)))
+        time_unit = adjustl(trim(units_lc(ispace+1:)))
+
+        if (len_trim(time_unit) <= 2) then
+          ierr = 20
+          message = trim(message)// "unsupported inverse-time unit '"//trim(time_unit)//"' in '"//trim(cunits)//"'"
+          return
+        end if
+
+        if (time_unit(len_trim(time_unit)-1:len_trim(time_unit)) /= "-1") then
+          ierr = 20
+          message = trim(message)// &
+            "unsupported inverse-time unit '"//trim(time_unit)// "' in '"//trim(cunits)//"'"
+          return
+        end if
+
+        ! Remove the trailing "-1".
+        time_unit = trim(time_unit(:len_trim(time_unit)-2))
+
+      case default
+
+        ierr = 20
+        message = trim(message)// "unsupported flux units '"//trim(cunits)// "': expected length/time, length per time, or length time-1"
+        return
+
+    end select
 
     ! Convert the numerator to millimetres
     select case (trim(length_unit))
 
-      case ("mm", "millimeter", "millimeters", &
-            "millimetre", "millimetres")
+      case ("mm", "millimeter", "millimeters", "millimetre", "millimetres")
         length_to_mm = 1._wp
 
-      case ("cm", "centimeter", "centimeters", &
-            "centimetre", "centimetres")
-        length_to_mm = 10._wp
-
-      case ("dm", "decimeter", "decimeters", &
-            "decimetre", "decimetres")
-        length_to_mm = 100._wp
-
-      case ("m", "meter", "meters", &
-            "metre", "metres")
+      case ("m", "meter", "meters", "metre", "metres")
         length_to_mm = 1000._wp
 
       case default
         ierr = 20
-        message = trim(message)// "unsupported length unit '"//trim(length_unit)// "' in '"//trim(cunits)//"'. Supported length units are: mm, cm, dm, m."
+        message = trim(message)// "unsupported length unit '"//trim(length_unit)// "' in '"//trim(cunits)//"'. Supported length units are: mm or m."
         return
 
     end select
@@ -405,16 +456,16 @@ contains
     select case (trim(time_unit))
 
       case ("s", "sec", "secs", "second", "seconds")
-        time_per_day = 86400._wp
+        units_per_day = 86400._wp
 
       case ("min", "mins", "minute", "minutes")
-        time_per_day = 1440._wp
+        units_per_day = 1440._wp
 
       case ("h", "hr", "hrs", "hour", "hours")
-        time_per_day = 24._wp
+        units_per_day = 24._wp
 
       case ("d", "day", "days")
-        time_per_day = 1._wp
+        units_per_day = 1._wp
 
       case default
         ierr = 20
@@ -423,11 +474,11 @@ contains
 
     end select
 
-    amult = length_to_mm * time_per_day
+    amult = length_to_mm * units_per_day
 
    end subroutine get_input_flux_multiplier
 
-  end subroutine get_forcing_varids
+  end subroutine get_forcing_metadata
 
 
   SUBROUTINE get_gforce_3d(info, itim_start, numtim, ierr, message)
@@ -447,7 +498,6 @@ contains
   ! ---------------------------------------------------------------------------------------
   USE multiforce,only:gForce_3d                          ! gridded forcing data
   USE multiforce,only:aValid                             ! time series of lumped forcing/response data
-  USE multiforce, only: amult_ppt, amult_pet, amult_q
 
   IMPLICIT NONE
 
@@ -497,10 +547,17 @@ contains
    ! save the data in the structure -- and convert fluxes to mm/day
    select case(ivar)
 
-    case (iPRECIP); gForce_3d(:,:,1:numtim)%ppt  = gTemp(:,:,:) * amult_ppt
-    case (iTEMP)  ; gForce_3d(:,:,1:numtim)%temp = gTemp(:,:,:)
-    case (iPET)   ; gForce_3d(:,:,1:numtim)%pet  = gTemp(:,:,:) * amult_pet
-    case (iQOBS)  ; aValid(   :,:,1:numtim)%obsq = gTemp(:,:,:) * amult_q
+    case (iPRECIP)
+      gForce_3d(:,:,1:numtim)%ppt = gTemp(:,:,:) * info%files%forc%multiplier(iPRECIP)
+
+    case (iTEMP)
+      gForce_3d(:,:,1:numtim)%temp = gTemp(:,:,:)
+
+    case (iPET)
+      gForce_3d(:,:,1:numtim)%pet = gTemp(:,:,:) * info%files%forc%multiplier(iPET)
+
+    case (iQOBS)
+      aValid(:,:,1:numtim)%obsq = gTemp(:,:,:) * info%files%forc%multiplier(iQOBS)   ! TODO: check dimensions (works for nx=1, ny=1)
     case default
       message=trim(message)//'unable to identify forcing variable'
       ierr=10; return

--- a/build/FUSE_SRC/prelim/par_derive.f90
+++ b/build/FUSE_SRC/prelim/par_derive.f90
@@ -5,7 +5,7 @@ module PAR_DERIVE_module
 
 contains
 
-  SUBROUTINE PAR_DERIVE(err,message)
+  SUBROUTINE PAR_DERIVE(info,err,message)
   ! ---------------------------------------------------------------------------------------
   ! Creator:
   ! --------
@@ -23,16 +23,18 @@ contains
   USE model_defn, ONLY: SMODL                          ! model definition structures
   USE model_defnames
   USE multiparam, ONLY: MPARAM,DPARAM                  ! model parameter structures
+  USE info_types, ONLY: fuse_info
   IMPLICIT NONE
   ! dummies
   integer(i4b),intent(out)::err
   character(*),intent(out)::message
+  TYPE(fuse_info), INTENT(IN) :: info
   ! ---------------------------------------------------------------------------------------
   err=0
   CALL BUCKETSIZE()        ! compute bucket size
   CALL MEAN_TIPOW()        ! mean of the power-transformed topo index
   CALL QBSATURATN()        ! compute baseflow at saturation (used in the SAC percolation model)
-  CALL QTIMEDELAY(err,message)        ! compute fraction of runoff in future time steps
+  CALL QTIMEDELAY(info,err,message)        ! compute fraction of runoff in future time steps
   if(err/=0)then
     err=10; message="f-PAR_DERIVE/&"//trim(message); return
   endif

--- a/build/FUSE_SRC/prelim/qtimedelay.f90
+++ b/build/FUSE_SRC/prelim/qtimedelay.f90
@@ -1,4 +1,4 @@
-SUBROUTINE QTIMEDELAY(err,message)
+SUBROUTINE QTIMEDELAY(info,err,message)
 ! ---------------------------------------------------------------------------------------
 ! Creator:
 ! --------
@@ -16,8 +16,9 @@ USE nrtype                                            ! variable types, etc.
 USE nr, ONLY : gammp                                  ! interface for the incomplete gamma function
 USE model_defn                                        ! model definition structure
 USE model_defnames
-USE multiforce                                        ! model forcing (need DELTIM)
 USE multiparam                                        ! model parameters
+USE info_types, ONLY: fuse_info
+USE multiroute, ONLY: FUTURE
 IMPLICIT NONE
 ! dummies
 integer(i4b),intent(out)::err
@@ -30,8 +31,64 @@ INTEGER(I4B)                           :: JTIM        ! (loop through future tim
 REAL(WP)                               :: TFUTURE     ! future time (units of days)
 REAL(WP)                               :: CUMPROB     ! cumulative probability at JTIM
 REAL(WP)                               :: PSAVE       ! cumulative probability at JTIM-1
+TYPE(fuse_info), INTENT(IN)            :: info
+INTEGER(I4B)                           :: ISTAT
 ! ---------------------------------------------------------------------------------------
 err=0
+
+! Compute the number of routing bins from the maximum routing horizon and the forcing timestep, both expressed in days.
+NTDH = CEILING(TDH_MAX / info%time%deltim_days, KIND=I4B)
+
+IF (NTDH < 2) THEN
+  ERR = 100
+  MESSAGE = 'f-QTIMEDELAY/at least two routing bins are required'
+  RETURN
+END IF
+
+! Allocate or resize the runoff fractions.
+IF (ALLOCATED(DPARAM%FRAC_FUTURE)) THEN
+  IF (SIZE(DPARAM%FRAC_FUTURE) /= NTDH) THEN
+    DEALLOCATE(DPARAM%FRAC_FUTURE, STAT=ISTAT)
+    IF (ISTAT /= 0) THEN
+      ERR = 100
+      MESSAGE = 'f-QTIMEDELAY/cannot deallocate DPARAM%FRAC_FUTURE'
+      RETURN
+    END IF
+  END IF
+END IF
+
+IF (.NOT.ALLOCATED(DPARAM%FRAC_FUTURE)) THEN
+  ALLOCATE(DPARAM%FRAC_FUTURE(NTDH), STAT=ISTAT)
+  IF (ISTAT /= 0) THEN
+    ERR = 100
+    MESSAGE = 'f-QTIMEDELAY/cannot allocate DPARAM%FRAC_FUTURE'
+    RETURN
+  END IF
+END IF
+
+! Allocate or resize the routing queue.
+IF (ALLOCATED(FUTURE)) THEN
+  IF (SIZE(FUTURE) /= NTDH) THEN
+    DEALLOCATE(FUTURE, STAT=ISTAT)
+    IF (ISTAT /= 0) THEN
+      ERR = 100
+      MESSAGE = 'f-QTIMEDELAY/cannot deallocate FUTURE'
+      RETURN
+    END IF
+  END IF
+END IF
+
+IF (.NOT.ALLOCATED(FUTURE)) THEN
+  ALLOCATE(FUTURE(NTDH), STAT=ISTAT)
+  IF (ISTAT /= 0) THEN
+    ERR = 100
+    MESSAGE = 'f-QTIMEDELAY/cannot allocate FUTURE'
+    RETURN
+  END IF
+
+  FUTURE = 0._WP
+END IF
+
 SELECT CASE(SMODL%iQ_TDH)
  CASE(iopt_rout_gamma) ! use a Gamma distribution with shape parameter = 2.5
   ALPHA = 2.5_WP                                             ! shape parameter
@@ -43,7 +100,7 @@ SELECT CASE(SMODL%iQ_TDH)
   NTDH = SIZE(DPARAM%FRAC_FUTURE)                            ! maximum number of future time steps
   ! loop through time steps and compute the fraction of runoff in future time steps
   DO JTIM=1,NTDH
-   TFUTURE                   = REAL(JTIM, WP)*DELTIM          ! future time (units of days)
+   TFUTURE                   = REAL(JTIM, WP)*info%time%deltim_days          ! future time (units of days)
    CUMPROB                   = GAMMP(ALPHA,ALAMB*TFUTURE)    ! cumulative probability at JTIM
    DPARAM%FRAC_FUTURE(JTIM)  = MAX(0._WP, CUMPROB-PSAVE)     ! probability between JTIM-1 and JTIM
    PSAVE                     = CUMPROB                       ! cumulative probability at JTIM-1

--- a/build/FUSE_SRC/runtime/get_time_windows.f90
+++ b/build/FUSE_SRC/runtime/get_time_windows.f90
@@ -195,6 +195,7 @@ module time_windows_module
     real(wp) :: dt_current
     real(wp) :: tolerance
     integer(i4b) :: i
+    logical(lgt), parameter :: do_timeCheck = .true.
 
     ierr=0; message="build_julian_axis/"
 
@@ -232,21 +233,27 @@ module time_windows_module
 
 
     ! Verify that the forcing time axis is increasing and regularly spaced.
-    do i = 3, size(jdate)
-      dt_current = (time_steps(i) - time_steps(i-1)) * scale_to_days
+    if (do_timeCheck) then
 
-      if (dt_current <= 0._wp) then
-        ierr = 1
-        message = trim(message)//"forcing time axis must be strictly increasing"
-        return
-      endif
+      do i = 3, size(jdate)
 
-      if (abs(dt_current - deltim_days) > tolerance) then
-         ierr = 1
-         message = trim(message)//"forcing time steps are not equally spaced"
-         return
-      endif
-    enddo
+        dt_current = (time_steps(i) - time_steps(i-1)) * scale_to_days
+
+        if (dt_current <= 0._wp) then
+          ierr = 1
+          message = trim(message)//"forcing time axis must be strictly increasing"
+          return
+        endif
+
+        if (abs(dt_current - deltim_days) > tolerance) then
+          ierr = 1
+          message = trim(message)//"forcing time steps are not equally spaced"
+          return
+        endif
+
+      enddo
+
+    endif
 
   end subroutine build_julian_axis
 

--- a/build/FUSE_SRC/runtime/get_time_windows.f90
+++ b/build/FUSE_SRC/runtime/get_time_windows.f90
@@ -13,7 +13,7 @@ module time_windows_module
   contains
 
   subroutine get_time_windows(ncid, info, ierr, message)
-    
+
     integer(i4b),      intent(in)    :: ncid
     type(fuse_info),   intent(inout) :: info
     integer(i4b),      intent(out)   :: ierr
@@ -21,7 +21,6 @@ module time_windows_module
 
     integer(i4b) :: nt
     character(len=1024) :: units_local
-    real(wp)            :: scale_to_days, dt_native, dt_days
     integer(i4b) :: ios
     character(len=1024) :: cmessage
 
@@ -36,7 +35,7 @@ module time_windows_module
     info%time%units     = trim(units_local)
 
     ! ----- build julian-day axis -------------------------------------------------------
-    
+
     call build_julian_axis(info%time%time_steps, trim(units_local), &
                            info%time%jdate_ref, info%time%jdate, info%time%deltim_days, ierr, cmessage)
     if(ierr/=0)then; message=trim(message)//trim(cmessage); return; endif
@@ -54,16 +53,16 @@ module time_windows_module
     if(ierr/=0)then; message=trim(message)//trim(cmessage); return; endif
 
     ! ----- validate window consistency -------------------------------------------------
-    
+
     call validate_windows(info%time, ierr, cmessage)
     if(ierr/=0)then; message=trim(message)//trim(cmessage); return; endif
 
     ! ----- derive simulation length ----------------------------------------------------
-    
+
     info%time%nt_sim = info%time%sim_end - info%time%sim_beg + 1
 
     ! ----- configure sub-period windowing ----------------------------------------------
-    
+
     ! convert sub-period string to integer
     read(info%config%numtim_sub_str,*,iostat=ios) info%time%nt_window
     if(ios/=0) then
@@ -90,7 +89,7 @@ module time_windows_module
   ! -------------------------------------------------------------------------------------
 
   ! ----- backwards compatibility: export to multiforce globals -------------------------
- 
+
   ! - New code stores all time-window metadata in info%time (source of truth).
   ! - Legacy routines still read multiforce globals (sim_beg, sim_end, numtim_sub, ...).
 
@@ -100,7 +99,7 @@ module time_windows_module
                           SUB_PERIODS_FLAG, istart, deltim
     implicit none
     type(fuse_info), intent(in) :: info
-   
+
     time_steps = info%time%time_steps
     timeUnits  = info%time%units
 
@@ -108,11 +107,11 @@ module time_windows_module
     sim_end    = info%time%sim_end
     eval_beg   = info%time%eval_beg
     eval_end   = info%time%eval_end
-   
+
     numtim_sim = info%time%nt_sim
     numtim_sub = info%time%nt_window
     SUB_PERIODS_FLAG = info%time%use_subperiods
-   
+
     istart = sim_beg
 
     deltim = info%time%deltim_days
@@ -127,11 +126,11 @@ module time_windows_module
   ! ----- helper: read time axis from NetCDF --------------------------------------------
 
   subroutine read_time_axis(ncid, time_steps, units, nt, ierr, message)
-    
+
     use netcdf
-    
+
     implicit none
-    
+
     integer(i4b), intent(in) :: ncid
     real(wp), allocatable, intent(out) :: time_steps(:)
     character(len=*), intent(out) :: units
@@ -180,7 +179,7 @@ module time_windows_module
   ! ----- helper: build julian axis -----------------------------------------------------
 
   subroutine build_julian_axis(time_steps, units, jref, jdate, deltim_days, ierr, message)
-    
+
     real(wp), intent(in) :: time_steps(:)
     character(len=*), intent(in) :: units
     real(wp), intent(out) :: jref
@@ -192,6 +191,10 @@ module time_windows_module
     integer(i4b) :: iy,im,id,ih
     character(len=1024) :: cmessage
     real(wp) :: scale_to_days
+
+    real(wp) :: dt_current
+    real(wp) :: tolerance
+    integer(i4b) :: i
 
     ierr=0; message="build_julian_axis/"
 
@@ -209,8 +212,41 @@ module time_windows_module
     if(ierr/=0) then; message=trim(message)//"allocate(jdate) failed"; return; endif
     jdate = jref + time_steps * scale_to_days
 
-    ! define length of forcing time steps
-    deltim_days = jdate(2) - jdate(1)
+    ! define the forcing timestep length in days
+    if (size(jdate) < 2) then
+      ierr = 1
+      message = trim(message)//"at least two forcing time steps are required"
+      return
+    endif
+
+    deltim_days = (time_steps(2) - time_steps(1)) * scale_to_days
+
+    if (deltim_days <= 0._wp) then
+      ierr = 1
+      message = trim(message)//"forcing time step must be positive"
+      return
+    endif
+
+    ! Allow for floating-point round-off in converted time coordinates
+    tolerance = epsilon(deltim_days) * 100._wp
+
+
+    ! Verify that the forcing time axis is increasing and regularly spaced.
+    do i = 3, size(jdate)
+      dt_current = (time_steps(i) - time_steps(i-1)) * scale_to_days
+
+      if (dt_current <= 0._wp) then
+        ierr = 1
+        message = trim(message)//"forcing time axis must be strictly increasing"
+        return
+      endif
+
+      if (abs(dt_current - deltim_days) > tolerance) then
+         ierr = 1
+         message = trim(message)//"forcing time steps are not equally spaced"
+         return
+      endif
+    enddo
 
   end subroutine build_julian_axis
 
@@ -224,15 +260,15 @@ module time_windows_module
     character(len=*), intent(in) :: units
     integer(i4b), intent(out) :: ierr
     character(*), intent(out) :: message
-   
+
     character(len=:), allocatable :: u
     integer(i4b) :: p
-   
+
     ierr=0; message="time_units_to_days/"
-   
+
     ! lower-case copy (simple approach)
     u = tolower_str( trim(adjustl(units)) )
-   
+
     ! Look at the first token before a space
     p = index(u, " ")
     if(p <= 1) then
@@ -240,7 +276,7 @@ module time_windows_module
       time_units_to_days = 0._wp
       return
     endif
-   
+
     select case (trim(u(1:p-1)))
       case ("days", "day")
         time_units_to_days = 1._wp
@@ -322,7 +358,7 @@ module time_windows_module
   ! ----- helper: validate sim/eval logic -----------------------------------------------
 
   subroutine validate_windows(ti, ierr, message)
- 
+
     use info_types, only: time_info
     type(time_info), intent(in) :: ti
     integer(i4b), intent(out) :: ierr

--- a/build/FUSE_SRC/share/model_defn_data.f90
+++ b/build/FUSE_SRC/share/model_defn_data.f90
@@ -6,6 +6,7 @@ MODULE model_defn
  ! Martyn Clark
  ! Modified by Brian Henn to include snow model, 6/2013
  ! Modified by Martyn Clark to separate type definitions from data storage, 01/2026
+ ! Modified by Cyril Thebault to allow sub-daily time step, 07/2026
  ! ---------------------------------------------------------------------------------------
  
  USE nrtype
@@ -16,7 +17,7 @@ MODULE model_defn
  implicit none
  private
 
- public :: NDEC, NTDH_MAX, NSTATE, N_FLUX
+ public :: NDEC, TDH_MAX, NSTATE, N_FLUX
  public :: LIST_RFERR, LIST_ARCH1, LIST_ARCH2, LIST_QSURF, LIST_QPERC, LIST_ESOIL, LIST_QINTF, LIST_Q_TDH, LIST_SNOWM
  public :: FNAME_PREFIX, FNAME_TEMPRY, FNAME_ASCII
  public :: FNAME_NETCDF_RUNS, FNAME_NETCDF_PARA, FNAME_NETCDF_PARA_SCE, FNAME_NETCDF_PARA_PRE
@@ -35,7 +36,7 @@ MODULE model_defn
  TYPE(DESC), DIMENSION(2)              :: LIST_SNOWM      ! snow model
  
  ! max steps in routing function
- INTEGER(I4B),PARAMETER::NTDH_MAX=500
+ INTEGER(I4B),PARAMETER                :: TDH_MAX = 500._WP ! Maximum routing delay horizon (days).
  
  ! model definitions
  CHARACTER(LEN=256)                    :: FNAME_NETCDF_RUNS    ! NETCDF output filename for model runs

--- a/build/FUSE_SRC/share/multiforce_data.f90
+++ b/build/FUSE_SRC/share/multiforce_data.f90
@@ -52,8 +52,6 @@ MODULE multiforce
  public :: ivarid_iy, ivarid_im, ivarid_id, ivarid_ih, ivarid_imin, ivarid_dsec
  public :: ivarid_ppt, ivarid_temp, ivarid_pet, ivarid_q
 
- public :: amult_ppt, amult_pet, amult_q
-
  public ::  NA_VALUE, NA_VALUE_SP
 
  SAVE
@@ -165,11 +163,6 @@ MODULE multiforce
  INTEGER(i4b)                          :: ivarid_temp = -1   ! variable ID for temperature
  INTEGER(i4b)                          :: ivarid_pet  = -1   ! variable ID for potential ET
  INTEGER(i4b)                          :: ivarid_q    = -1   ! variable ID for runoff
-
-  ! multipliers for variables to convert fluxes to mm/day
- REAL(WP)                              :: amult_ppt = -1._wp ! convert precipitation to mm/day
- REAL(WP)                              :: amult_pet = -1._wp ! convert potential ET to mm/day
- REAL(WP)                              :: amult_q   = -1._wp ! convert runoff to mm/day
 
  ! missing values
  INTEGER(I4B),PARAMETER                :: NA_VALUE    = -9999     ! integer designating missing values - TODO: retrieve from NetCDF file

--- a/build/FUSE_SRC/share/multiroute_data.f90
+++ b/build/FUSE_SRC/share/multiroute_data.f90
@@ -1,7 +1,6 @@
 MODULE multiroute
 
  USE nrtype
- USE model_defn,ONLY:NTDH_MAX
  USE multiroute_types, only: RUNOFF
 
  implicit none
@@ -11,7 +10,7 @@ MODULE multiroute
  public :: AROUTE, AROUTE_3d
  public :: MROUTE
 
- REAL(WP), DIMENSION(NTDH_MAX)                :: FUTURE     ! runoff placed in future time steps
+ REAL(WP), ALLOCATABLE                        :: FUTURE(:)  ! runoff placed in future time steps
 
  TYPE(RUNOFF), DIMENSION(:), POINTER          :: AROUTE     ! runoff for all time steps
  TYPE(RUNOFF),dimension(:,:,:), allocatable   :: AROUTE_3d  ! runoff for all time steps on a grid

--- a/build/FUSE_SRC/types/info_types.f90
+++ b/build/FUSE_SRC/types/info_types.f90
@@ -101,6 +101,7 @@ module info_types
  type :: forcing_vars
   character(len=64), allocatable :: name(:)   ! NFORC
   integer(i4b),      allocatable :: varid(:)  ! NFORC
+  real(wp),          allocatable :: multiplier(:)
  end type
 
  ! ---

--- a/build/FUSE_SRC/types/multiparam_types.f90
+++ b/build/FUSE_SRC/types/multiparam_types.f90
@@ -9,7 +9,6 @@ MODULE multiparam_types
  ! ---------------------------------------------------------------------------------------
  
  USE nrtype
- USE model_defn, ONLY: NTDH_MAX
  
  implicit none
  private
@@ -162,7 +161,7 @@ MODULE multiparam_types
   REAL(WP)                             :: POWLAMB     ! mean value of the power-transformed topographic index (m**(1/n))
   REAL(WP)                             :: MAXPOW      ! max value of the power-transformed topographic index (m**(1/n))
   ! routing
-  REAL(WP), DIMENSION(NTDH_MAX)        :: FRAC_FUTURE ! fraction of runoff in future time steps
+  REAL(WP), ALLOCATABLE                :: FRAC_FUTURE(:) ! fraction of runoff in future time steps
   INTEGER(I4B)                         :: NTDH_NEED   ! number of time-steps with non-zero routing contribution
  END TYPE PARDVD
  

--- a/build/FUSE_SRC/util/alloc_domain.f90
+++ b/build/FUSE_SRC/util/alloc_domain.f90
@@ -73,8 +73,9 @@ CONTAINS
   if(ierr/=0)then; message=trim(message)//"cannot allocate elev bands (var)"; return; endif
 
   ! allocate forcing lookup table
-  allocate(info%files%forc%name(NVAR_FORC), info%files%forc%varid(NVAR_FORC), stat=ierr)
+  allocate(info%files%forc%name(NVAR_FORC), info%files%forc%varid(NVAR_FORC), info%files%forc%multiplier(NVAR_FORC), stat=ierr)
   if(ierr/=0)then; message=trim(message)//"cannot allocate forcing lookup table"; return; endif
+  info%files%forc%multiplier(:) = -1._wp
 
   end subroutine allocate_domain_data
 


### PR DESCRIPTION
## Summary

This PR adds support for sub-daily forcing time steps and automatic conversion of input fluxes units.

### Main changes

- compute routing dimensions from the forcing time step
- validate that forcing time coordinates are positive, increasing and regularly spaced
- read NetCDF units independently for precipitation, PET and observed streamflow
- automatically convert supported flux units to the internal `mm/day` representation
- improve error messages for unsupported units

### Supported units

Length:
- mm
- cm
- dm
- m

Time:
- s
- min
- h
- d

Both `length/time` and `length per time` syntaxes are supported (case-insensitive, with common aliases such as `hour`, `hours`, `hr`, etc.).

### Testing

- daily simulations reproduce previous results
- hourly simulations reproduce the reference results
- mixed units across forcing variables are handled correctly
- unsupported units produce informative error messages